### PR TITLE
fix: 解决x11下开启滤镜全屏连拍，左上角画面会闪烁的问题

### DIFF
--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -77,7 +77,9 @@ videowidget::videowidget(DWidget *parent)
       m_imgPrcThread(nullptr),
       m_nMaxRecTime(60), //默认60小时
       m_openglwidget(nullptr),
-      m_gridlinewidget(nullptr)
+      m_gridlinewidget(nullptr),
+      m_filterType(filter_Normal),
+      m_exposure(0)
 {
 #ifndef __mips__
     if (!get_wayland_status()) {
@@ -813,7 +815,7 @@ void videowidget::flash()
 
 #ifndef __mips__
     if (!get_wayland_status())
-        if (m_openglwidget->isVisible() == false)
+        if (m_openglwidget->isVisible() == false && m_filterType == filter_Normal && m_exposure == 0)
             m_openglwidget->show();
 
 #endif
@@ -1387,6 +1389,7 @@ void videowidget::setMaxRecTime(int hour)
 
 void videowidget::setFilterType(efilterType type)
 {
+    m_filterType = type;
     if (m_imgPrcThread)
         m_imgPrcThread->setFilter(filterPreviewButton::filterName_CUBE(type));
 }
@@ -1437,6 +1440,7 @@ void videowidget::setGridType(GridType type)
 
 void videowidget::onExposureChanged(int exposure)
 {
+    m_exposure = exposure;
     if (m_imgPrcThread)
         m_imgPrcThread->setExposure(exposure);
 }

--- a/src/src/videowidget.h
+++ b/src/src/videowidget.h
@@ -447,6 +447,10 @@ private:
     QGraphicsTextItem          *m_pCamErrItem;      //摄像头异常提示
     bool                       m_flashEnable;       //是否闪光灯
     bool                       m_bPhoto = true;     //相机当前状态，默认为拍照状态
+
+    efilterType                m_filterType;            //当前选择的滤镜名称
+    int                        m_exposure;
+
 };
 
 #endif // VIDEOWIDGET_H


### PR DESCRIPTION
Description: 解决x11下开启滤镜全屏连拍，左上角画面会闪烁的问题

Log: 解决x11下开启滤镜全屏连拍，左上角画面会闪烁的问题

Bug: https://pms.uniontech.com/bug-view-118753.html