### PR TITLE
fix: 解决MIPS架构使用gstreamer编码库，录制的视频时长不正确的问题

### DIFF
--- a/src/src/gstvideowriter.h
+++ b/src/src/gstvideowriter.h
@@ -60,14 +60,16 @@ protected:
     void loadAppSrcCaps();
 
 private:
-    QString                     m_videoPath;
+    QString                     m_videoPath; //视频保存路径
     uint                        m_nWidth; // 录制视频分辨率宽度
     uint                        m_nHeight; // 录制视频分辨率高度
-    uint                        m_nFrameRate;// 帧率
-    uint                        m_nQuantizer;//成像质量 范围4-63, 默认为44 值约小，成像质量越高，视频画面越清晰，编码耗时越长，视频文件占用磁盘控件越大
-    uint                        m_nEncodeThreadNum;//编码多线程数量 默认为 6
+    uint                        m_nFrameRate; // 帧率
+    uint                        m_nQuantizer; // 成像质量 范围4-63, 默认为44 值约小，成像质量越高，视频画面越清晰，编码耗时越长，视频文件占用磁盘控件越大
+    uint                        m_nEncodeThreadNum; //编码多线程数量 默认为 6
+    uint                        m_nSkipFrames; // 跳帧处理,默认不抽帧
+    uint                        m_nFrameNum; // 帧编号
 
-    GstElement                 *m_pipeline;
+    GstElement                 *m_pipeline; // 管道实例
     GMainLoop                  *m_gloop;
     GstElement                 *m_appsrc;
     GstElement                 *m_audsrc;

--- a/src/src/majorimageprocessingthread.h
+++ b/src/src/majorimageprocessingthread.h
@@ -193,7 +193,8 @@ private:
     QAtomicInt        m_stopped;
     v4l2_dev_t        *m_videoDevice;
     v4l2_frame_buff_t *m_frame;
-    uint8_t           *m_yuvPtr;
+    uint8_t           *m_yuvPtr;// yu12视频帧数据
+    uint8_t           *m_rgbPtr;// rgb视频帧数据
 
     bool              m_bPhoto = true; //相机当前状态，默认为拍照状态
     bool              m_bRecording;//是否处理视频录制状态 GStreamer环境下使用


### PR DESCRIPTION
Description: MIPS架构下，通过增加线程提升编码效率，降低录制帧率和成像质量，来减少视频录制所耗时间，避免出现视频时长不正确的情况

Log: MIPS架构使用gstreamer编码库，录制的视频时长不正确

Bug: https://pms.uniontech.com/bug-view-123491.html