### PR TITLE
fix: 解决滤镜/曝光调节，程序闪退的问题

### DIFF
--- a/src/src/gstvideowriter.cpp
+++ b/src/src/gstvideowriter.cpp
@@ -111,11 +111,7 @@ void GstVideoWriter::start()
     // 设置视频帧数据格式
     loadAppSrcCaps();
 
-#ifndef __mips__
-    m_nSkipFrames = 1;
-    setQuantizer(NORMAL_QUANTIZER);
-    setEncodeThreadNum(NORMAL_ENCODETHREAD);
-#else
+#if defined(__mips__)
     // mips下，牺牲了帧率和成像质量，保证录像不会耗费太多时间
     m_nSkipFrames = 3;
     if (m_nWidth >= 1920) {
@@ -134,6 +130,29 @@ void GstVideoWriter::start()
         setQuantizer(NORMAL_QUANTIZER);
         setEncodeThreadNum(NORMAL_ENCODETHREAD);
     }
+#elif defined(__aarch64__)
+    // mips下，牺牲了帧率和成像质量，保证录像不会耗费太多时间
+    m_nSkipFrames = 3;
+    if (m_nWidth >= 1920) {
+        setQuantizer(62);
+        setEncodeThreadNum(12);
+    }
+    else if (m_nWidth >= 1280) {
+        setQuantizer(62);
+        setEncodeThreadNum(12);
+    }
+    else if (m_nWidth >= 800) {
+        setQuantizer(62);
+        setEncodeThreadNum(10);
+    }
+    else {
+        setQuantizer(NORMAL_QUANTIZER);
+        setEncodeThreadNum(NORMAL_ENCODETHREAD);
+    }
+#else
+    m_nSkipFrames = 1;
+    setQuantizer(NORMAL_QUANTIZER);
+    setEncodeThreadNum(NORMAL_ENCODETHREAD);
 #endif
 
     // 启动管道

--- a/src/src/majorimageprocessingthread.cpp
+++ b/src/src/majorimageprocessingthread.cpp
@@ -276,6 +276,8 @@ void MajorImageProcessingThread::run()
                     m_rgbPtr = static_cast<uint8_t *>(calloc(rgbsize, sizeof(uint8_t)));
                 } else {
                     rgbsize = m_nVdWidth * m_nVdHeight * 3;
+                    if (nullptr == m_rgbPtr)
+                        m_rgbPtr = static_cast<uint8_t *>(calloc(rgbsize, sizeof(uint8_t)));
                 }
 
                 if (FFmpeg_Env == m_eEncodeEnv) {


### PR DESCRIPTION
Description: 调节滤镜/曝光后，rgb帧数据未分配内存，程序因访问空指针crash

Log: 解决滤镜/曝光调节，程序闪退的问题

Bug: https://pms.uniontech.com/bug-view-124535.html,https://pms.uniontech.com/bug-view-124537.html