### PR TITLE
fix: build failure on Arch due to missing include

### DIFF
--- a/src/src/windowstatethread.h
+++ b/src/src/windowstatethread.h
@@ -23,6 +23,7 @@
 #include <DMainWindow>
 #include <DForeignWindow>
 
+#include <thread>
 #include <QThread>
 #include <QMutex>
 


### PR DESCRIPTION
Fixes the following build failure on Arch, probably due to new compiler version:

```
/build/deepin-camera/src/deepin-camera-1.3.10/src/src/windowstatethread.cpp: In member function ‘virtual void windowStateThread::run()’:
/build/deepin-camera/src/deepin-camera-1.3.10/src/src/windowstatethread.cpp:45:27: error: ‘sleep_for’ is not a member of ‘std::this_thread’
   45 |         std::this_thread::sleep_for(std::chrono::seconds(1));
      |                           ^~~~~~~~~
```

Log: Fix build failure on Arch due to missing include