### PR TITLE
fix: compatibility with FFmpeg 5

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -480,10 +480,6 @@ static encoder_video_context_t *encoder_video_init(encoder_context_t *encoder_ct
 
     video_codec_data->codec_context = getLoadLibsInstance()->m_avcodec_alloc_context3(video_codec_data->codec);
 
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3 (
-			video_codec_data->codec_context,
-			video_codec_data->codec);
-
 	if(video_codec_data->codec_context == NULL)
 	{
 		fprintf(stderr, "ENCODER: FATAL memory allocation failure (encoder_video_init): %s\n", strerror(errno));
@@ -747,7 +743,6 @@ static encoder_audio_context_t *encoder_audio_init(encoder_context_t *encoder_ct
 	}
 
     audio_codec_data->codec_context = getLoadLibsInstance()->m_avcodec_alloc_context3(audio_codec_data->codec);
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3 (audio_codec_data->codec_context, audio_codec_data->codec);
 
 	if(audio_codec_data->codec_context == NULL)
 	{

--- a/libcam/libcam_v4l2core/jpeg_decoder.c
+++ b/libcam/libcam_v4l2core/jpeg_decoder.c
@@ -1415,7 +1415,6 @@ int jpeg_init_decoder(int width, int height)
 
 #if LIBAVCODEC_VER_AT_LEAST(53,6)
     codec_data->context = getLoadLibsInstance()->m_avcodec_alloc_context3(codec_data->codec);
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3 (codec_data->context, codec_data->codec);
 #else
     codec_data->context = getLoadLibsInstance()->m_avcodec_alloc_context();
     getLoadLibsInstance()->m_avcodec_get_context_defaults(codec_data->context);

--- a/libcam/libcam_v4l2core/uvc_h264.c
+++ b/libcam/libcam_v4l2core/uvc_h264.c
@@ -1006,7 +1006,6 @@ int h264_init_decoder(int width, int height)
 
 #if LIBAVCODEC_VER_AT_LEAST(53,6)
     h264_ctx->context = getLoadLibsInstance()->m_avcodec_alloc_context3(h264_ctx->codec);
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3 (h264_ctx->context, h264_ctx->codec);
 #else
     h264_ctx->context = getLoadLibsInstance()->m_avcodec_alloc_context();
     getLoadLibsInstance()->m_avcodec_get_context_defaults(h264_ctx->context);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ static bool CheckFFmpegEnv()
     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
     dir.setPath(path);
     QStringList list = dir.entryList(QStringList() << (QString("libavcodec") + "*"), QDir::NoDotAndDotDot | QDir::Files);
-    if (list.contains("libavcodec.so.58")) {
+    if (list.contains("libavcodec.so")) {
         return true;
     }
     return false;

--- a/src/src/basepub/load_libs.c
+++ b/src/src/basepub/load_libs.c
@@ -67,8 +67,6 @@ static LoadLibs *newClass(void)
     PrintError();
     pLibs->m_avcodec_free_context = (uos_avcodec_free_context)dlsym(handle,"avcodec_free_context");
     PrintError();
-    pLibs->m_avcodec_get_context_defaults3 = (uos_avcodec_get_context_defaults3)dlsym(handle, "avcodec_get_context_defaults3");
-    PrintError();
 #else
     pLibs->m_avcodec_alloc_context = (uos_avcodec_alloc_context)dlsym(handle, "avcodec_alloc_context");
     PrintError();

--- a/src/src/basepub/load_libs.h
+++ b/src/src/basepub/load_libs.h
@@ -43,8 +43,6 @@ typedef AVCodec *(*uos_avcodec_find_encoder_by_name)(const char *name);
 typedef AVCodecContext *(*uos_avcodec_alloc_context)(const AVCodec *codec);
 typedef void (*uos_avcodec_free_context)(AVCodecContext **avctx);
 typedef AVCodecContext *(*uos_avcodec_alloc_context3)(const AVCodec *codec);
-//int avcodec_get_context_defaults3(AVCodecContext *s, const AVCodec *codec);
-typedef int (*uos_avcodec_get_context_defaults3)(AVCodecContext *s, const AVCodec *codec);
 //int avcodec_open2(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options);
 typedef int (*uos_avcodec_open2)(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options);
 //void avcodec_flush_buffers(AVCodecContext *avctx);
@@ -116,7 +114,6 @@ typedef struct _LoadLibs {
     uos_avcodec_alloc_context m_avcodec_alloc_context;
     uos_avcodec_free_context m_avcodec_free_context;
     uos_avcodec_alloc_context3 m_avcodec_alloc_context3;
-    uos_avcodec_get_context_defaults3 m_avcodec_get_context_defaults3;
     uos_avcodec_open2 m_avcodec_open2;
     uos_avcodec_flush_buffers m_avcodec_flush_buffers;
     uos_avcodec_close m_avcodec_close;


### PR DESCRIPTION
avcodec_get_context_defaults3 has been marked as deprecated since FFmpeg
4.0: https://ffmpeg.org/doxygen/4.0/group__lavc__core.html#ga1dd4bf43e6a4ec8b8d76bd3673e5e73a

Tested to be working fine on Arch with FFmpeg 5.1.

Log: Fix compatibility with FFmpeg 5