### PR TITLE
fix: 修复默认视频格式不为mp4问题

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,10 +82,18 @@ static bool CheckFFmpegEnv()
     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
     dir.setPath(path);
     QStringList list = dir.entryList(QStringList() << (QString("libavcodec") + "*"), QDir::NoDotAndDotDot | QDir::Files);
+    QString libName = nullptr;
+    QRegExp re("libavcodec.so.*"); //Sometimes libavcodec.so may not exist, so find it through regular expression.
+    for (int i = 0; i < list.count(); i++) {
+        if (re.exactMatch(list[i])) {
+            libName = list[i];
+            break;
+        }
+    }
 
-    if (list.contains("libavcodec.so") || list.contains("libavcodec.so.58")) {
+    if (libName != nullptr) {
         QLibrary libavcodec;  //检查编码器是否存在
-        libavcodec.setFileName("libavcodec.so");
+        libavcodec.setFileName(libName);
         qDebug() << "Whether the libavcodec is loaded successfully: "<< libavcodec.load();
         typedef AVCodec *(*p_avcodec_find_encoder)(enum AVCodecID id);
         p_avcodec_find_encoder m_avcodec_find_encoder = nullptr;


### PR DESCRIPTION
通过正则表达式匹配libavcodec库文件

Log: 通过正则表达式匹配libavcodec库文件

Bug: https://pms.uniontech.com/bug-view-183421.html