### PR TITLE
fix: wayland锁屏后拔插摄像头崩溃问题

### DIFF
--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -1400,6 +1400,10 @@ void CMainWindow::onTimeoutLock(const QString &serviceName, QVariantMap key2valu
             onStopPhotoAndRecord();
 
             m_videoPre->m_imgPrcThread->stop();
+
+            v4l2_dev_t *vd =  get_v4l2_device_handler();
+            if (vd != nullptr)
+                close_v4l2_device_handler();
             qDebug() << "lock end";
         } else {
             qDebug() << "restart use camera cause ScreenBlack or PoweerLock";


### PR DESCRIPTION
修复wayland锁屏后拔插摄像头，解锁后点击录像按钮崩溃

Log: 修复wayland锁屏后拔插摄像头崩溃问题

Bug: https://pms.uniontech.com/bug-view-198571.html