### PR TITLE
fix: 修复USB声卡端口状态正常，但无法获取音频数据时录像崩溃问题

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -1791,9 +1791,14 @@ int encoder_encode_audio(encoder_context_t *encoder_ctx, void *audio_data)
 
 	encoder_audio_context_t *enc_audio_ctx = encoder_ctx->enc_audio_ctx;
 
-	int outsize = 0;
+    int outsize = 0;
 
-	if(!enc_audio_ctx)
+    if (!audio_data) {
+        fprintf(stderr, "ENCODER: audio_data is empty.");
+        return outsize;
+    }
+
+    if(!enc_audio_ctx)
 	{
 		if(verbosity > 1)
 			printf("ENCODER: audio encoder not set\n");


### PR DESCRIPTION
规避USB声卡端口状态正常，但无法获取音频数据时，点击结束录像崩溃问题

Log: 规避USB声卡端口状态正常，但无法获取音频数据时录像崩溃问题

Bug: https://pms.uniontech.com/bug-view-207319.html