### PR TITLE
fix: remove unused dframeworkdbus from debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>=9),cmake,
  pkg-config,qtbase5-dev,libdtkgui-dev,libdtkwidget-dev,qtmultimedia5-dev,
  libavutil-dev, libavformat-dev, libavcodec-dev,libavfilter-dev,qttools5-dev,
- qttools5-dev-tools,deepin-gettext-tools,libdframeworkdbus-dev,
+ qttools5-dev-tools,deepin-gettext-tools,
  libv4l-dev,libsdl2-dev,portaudio19-dev,libpng-dev,libasound2-dev,libpciaccess-dev,
  libusb-1.0-0-dev,zlib1g-dev,libudev-dev,libswscale-dev,libswresample-dev,libffmpegthumbnailer-dev,
  libx11-dev,libva-dev,libimageeditor-dev,


### PR DESCRIPTION
It's no longer in use.