### PR TITLE
fix: MP4录制出的视频内容少一到二秒的内容

### DIFF
--- a/libcam/libcam_encoder/video_codecs.c
+++ b/libcam/libcam_encoder/video_codecs.c
@@ -387,7 +387,7 @@ static video_codec_t listSupCodecs[] =
 		.trellis      = 0,
 		.me_method    = X264_ME_HEX,
 		.mpeg_quant   = 1,
-		.max_b_frames = 16,
+		.max_b_frames = 4,
 		.num_threads  = 4,
 #if LIBAVCODEC_VER_AT_LEAST(54,01)
 		.flags        = CODEC_FLAG2_INTRA_REFRESH


### PR DESCRIPTION
MP4录制出的视频内容少一到二秒的内容

Log: MP4录制出的视频内容少一到二秒的内容

Bug: https://pms.uniontech.com/bug-view-217973.html