### PR TITLE
fix: 打开相机下方概率性出现静态图

### DIFF
--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -433,6 +433,13 @@ void videowidget::ReceiveOpenGLstatus(bool result)
 
 void videowidget::ReceiveMajorImage(QImage *image, int result)
 {
+    // 若窗口高度改变，需要刷新整个窗口，防止上一帧图像出现在其它区域
+    static int height = this->height();
+    if (height != this->height()) {
+        update();
+        height = this->height();
+    }
+
     if (!image->isNull()) {
         switch (result) {
         case 0:     //Success
@@ -452,9 +459,8 @@ void videowidget::ReceiveMajorImage(QImage *image, int result)
             if (m_openglwidget && m_openglwidget->isVisible())
                 m_openglwidget->hide();
             {
-                // OpenGL窗口等比例缩放画面
-                int widgetwidth = width();
-                int widgetheight = height();
+                int widgetwidth = this->width();
+                int widgetheight = this->height();
                 if ((image->width() * 100 / image->height()) > (widgetwidth * 100 / widgetheight)) {
                     QImage img = image->scaled(widgetwidth, widgetwidth * image->height() / image->width(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
                     m_framePixmap = QPixmap::fromImage(img);


### PR DESCRIPTION
修复打开相机时下方概率性出现静态图像的问题

Log: 修复打开相机时下方概率性出现静态图像的问题

Bug: https://pms.uniontech.com/bug-view-227191.html