### PR TITLE
fix: 高分辨率录像多次点击开始/结束导致崩溃

### DIFF
--- a/libcam/libcam/camview.c
+++ b/libcam/libcam/camview.c
@@ -108,6 +108,8 @@ static uint8_t soundTakePhoto = 1;//拍照声音提示
 
 static char status_message[80];
 
+static int encode_thread_running = 0;
+
 
 void set_video_time_capture(double video_time)
 {
@@ -1290,13 +1292,18 @@ void *capture_loop(void *data)
  */
 int start_encoder_thread(void *data)
 {
+    if (encode_thread_running)
+        return 0;
+
     int ret = __THREAD_CREATE(&encoder_thread, encoder_loop, data);
 
-    if(ret)
+    if(ret) {
         fprintf(stderr, "deepin-camera: encoder thread creation failed (%i)\n", ret);
-    else if(debug_level > 2)
-        printf("deepin-camera: created encoder thread with tid: %u\n",
-            (unsigned int) encoder_thread);
+    } else {
+        if(debug_level > 2)
+            printf("deepin-camera: created encoder thread with tid: %u\n", (unsigned int) encoder_thread);
+        encode_thread_running = 1;
+    }
 
     return ret;
 }
@@ -1323,6 +1330,8 @@ int stop_encoder_thread()
 
     if(debug_level > 1)
         printf("deepin-camera: encoder thread terminated and joined\n");
+
+    encode_thread_running = 0;
 
     return 0;
 }

--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -1518,7 +1518,6 @@ static int libav_send_encode(AVCodecContext *avctx, AVFrame *frame)
         fprintf(stderr, "ENCODER: codec not an encoder\n");
 
     if (frame) {
-
         if (avctx->codec_type == AVMEDIA_TYPE_AUDIO && frame->nb_samples != avctx->frame_size)
             fprintf(stderr, "ENCODER: audio samples differ from frame size\n");
         if (avctx->codec_type == AVMEDIA_TYPE_AUDIO && frame->channels <= 0) {
@@ -1756,7 +1755,7 @@ int encoder_encode_audio(encoder_context_t *encoder_ctx, void *audio_data)
     int outsize = 0;
 
     if (!audio_data) {
-        fprintf(stderr, "ENCODER: audio_data is empty.");
+        fprintf(stderr, "ENCODER: audio_data is empty.\n");
         return outsize;
     }
 
@@ -1994,7 +1993,7 @@ void encoder_close(encoder_context_t *encoder_ctx)
     /*close audio codec*/
     if (enc_audio_ctx) {
         //测试video时长是否正常
-        printf("video_duration:%d", enc_audio_ctx->duration);
+        printf("video_duration:%d\n", enc_audio_ctx->duration);
         audio_codec_data = (encoder_codec_data_t *) enc_audio_ctx->codec_data;
         if (audio_codec_data) {
             getLoadLibsInstance()->m_avcodec_flush_buffers(audio_codec_data->codec_context);


### PR DESCRIPTION
修复高分辨率录像多次点击开始/结束导致崩溃问题，高分辨率录像时，编码线程释放时间较长，导致上一个线程还未释放完成，又创建了一个新的线程

Log: 修复高分辨率录像多次点击开始/结束导致崩溃问题

Bug: https://pms.uniontech.com/bug-view-228159.html