### PR TITLE
fix: 修复v23 连上usb相机或自带相机笔记本启动相机时奔溃问题

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -512,7 +512,7 @@ static encoder_video_context_t *encoder_video_init(encoder_context_t *encoder_ct
 
     video_codec_data->codec_context = getLoadLibsInstance()->m_avcodec_alloc_context3(video_codec_data->codec);
 
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3(
+    getLoadLibsInstance()->m_avcodec_get_context_defaults3 && getLoadLibsInstance()->m_avcodec_get_context_defaults3(
         video_codec_data->codec_context,
         video_codec_data->codec);
 
@@ -761,7 +761,7 @@ static encoder_audio_context_t *encoder_audio_init(encoder_context_t *encoder_ct
     }
 
     audio_codec_data->codec_context = getLoadLibsInstance()->m_avcodec_alloc_context3(audio_codec_data->codec);
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3(audio_codec_data->codec_context, audio_codec_data->codec);
+    getLoadLibsInstance()->m_avcodec_get_context_defaults3 && getLoadLibsInstance()->m_avcodec_get_context_defaults3(audio_codec_data->codec_context, audio_codec_data->codec);
 
     if (audio_codec_data->codec_context == NULL) {
         fprintf(stderr, "ENCODER: FATAL memory allocation failure (encoder_audio_init): %s\n", strerror(errno));

--- a/libcam/libcam_v4l2core/jpeg_decoder.c
+++ b/libcam/libcam_v4l2core/jpeg_decoder.c
@@ -1415,7 +1415,7 @@ int jpeg_init_decoder(int width, int height)
 
 #if LIBAVCODEC_VER_AT_LEAST(53,6)
     codec_data->context = getLoadLibsInstance()->m_avcodec_alloc_context3(codec_data->codec);
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3 (codec_data->context, codec_data->codec);
+     getLoadLibsInstance()->m_avcodec_get_context_defaults3 && getLoadLibsInstance()->m_avcodec_get_context_defaults3 (codec_data->context, codec_data->codec);
 #else
     codec_data->context = getLoadLibsInstance()->m_avcodec_alloc_context();
     getLoadLibsInstance()->m_avcodec_get_context_defaults(codec_data->context);

--- a/src/src/majorimageprocessingthread.cpp
+++ b/src/src/majorimageprocessingthread.cpp
@@ -14,6 +14,8 @@ extern "C" {
 #include <QFile>
 #include <QDate>
 #include <QDir>
+#include <DSysInfo>
+DCORE_USE_NAMESPACE
 
 MajorImageProcessingThread::MajorImageProcessingThread():m_bHorizontalMirror(false)
 {
@@ -250,6 +252,9 @@ void MajorImageProcessingThread::run()
 #if defined(_loongarch) || defined(__loongarch__) || defined(__loongarch64) || defined (__mips__)
             bUseRgb = true;
 #endif
+            if(DSysInfo::majorVersion() == "23") {
+                bUseRgb = true;
+            }
             if (get_wayland_status())
                 bUseRgb = true;
 


### PR DESCRIPTION
修复v23 连上usb相机或自带相机笔记本启动相机时奔溃问题

Bug: https://pms.uniontech.com/bug-view-238775.html
Log: 更新ffmpeg版本后，修复v23 连上usb相机或自带相机笔记本启动相机时奔溃问题