### PR TITLE
fix: modify the default video format for recording to webm 2nd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,9 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/assets/deepin-camera DESTINATION ${CMAKE
 #debus_service
 install(FILES ${PROJECT_SOURCE_DIR}/com.deepin.Camera.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services)
 
+# Install camera config file.
+install(FILES assets/camera.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-camera)
+
 ##translations
 #install(FILES ${PROJECT_SOURCE_DIR}/translations/*.qm DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_SOURCE_DIR}/translations)
 

--- a/src/assets/camera.conf
+++ b/src/assets/camera.conf
@@ -1,0 +1,2 @@
+[General]
+LowPerformanceBoard=600F,NZ275D,GWMNDA1GL1

--- a/src/src/Settings.cpp
+++ b/src/src/Settings.cpp
@@ -49,7 +49,7 @@ void Settings::init()
     QStringList videoFormatList;
     if (DataManager::instance()->encodeEnv() == FFmpeg_Env) {
         if (DataManager::instance()->encExists()) {
-            if (!GlobalUtils::isBXCBoard()) {
+            if (!GlobalUtils::isLowPerformanceBoard()) {
                 videoFormatList << tr("mp4") << tr("webm");
             } else {
                 videoFormatList << tr("webm") << tr("mp4");

--- a/src/src/globalutils.h
+++ b/src/src/globalutils.h
@@ -11,7 +11,14 @@
 class GlobalUtils
 {
 public:
-    static bool isBXCBoard();
+    // 判断是否为低性能主板
+    static bool isLowPerformanceBoard();
+
+    // 加载相机配置
+    static void loadCameraConf();
+
+private:
+    static QStringList m_LowPerformanceBoards;
 };
 
 #endif // GLOBALUTILS_H

--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include "camera.h"
 #include "eventlogutils.h"
 #include "config.h"
+#include "globalutils.h"
 
 #include <DLabel>
 #include <DApplication>
@@ -768,6 +769,8 @@ CMainWindow::CMainWindow(QWidget *parent)
     titlebar()->deleteLater();
     setupTitlebar();
     m_pTitlebar->raise();
+
+    GlobalUtils::loadCameraConf();
 
     //修复在性能较差的电脑上启动闪烁白框
     initUI();

--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -215,11 +215,11 @@ videowidget::videowidget(DWidget *parent)
     // 默认不显示网格线
     setGridType(Grid_None);
 
-    if (DataManager::instance()->encodeEnv() != FFmpeg_Env || !DataManager::instance()->encExists() || GlobalUtils::isBXCBoard()) {
+    if (DataManager::instance()->encodeEnv() != FFmpeg_Env || !DataManager::instance()->encExists() || GlobalUtils::isLowPerformanceBoard()) {
         m_videoFormat = "webm";
     }
     if (dc::Settings::get().getOption("outsetting.outformat.vidformat").toInt()) {
-        if (!GlobalUtils::isBXCBoard())
+        if (!GlobalUtils::isLowPerformanceBoard())
             m_videoFormat = "webm";
         else
             m_videoFormat = "mp4";


### PR DESCRIPTION
   For some hardware,such as CC GWMNDA1GL1 modify the default video format for recording to webm

Log: modify the default video format for recording to webm 2nd
Bug: https://pms.uniontech.com/bug-view-237059.html