### PR TITLE
fix: 修复ffmpeg升级后安装依赖报错

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.0.8) unstable; urgency=medium
+
+  * tag 6.0.8
+
+ -- shuaijie <shuaijie@uniontech.com>  Tue, 09 Apr 2024 16:12:13 +0800
+
 deepin-camera (6.0.7) unstable; urgency=medium
 
   * fix: Fix the issue of crashing when connecting to a USB camera or a laptop with a built-in camera in v23 and starting the camera(Bug: 238775)

--- a/debian/control
+++ b/debian/control
@@ -21,9 +21,11 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
- libasound2 (>= 1.0.16), libavcodec58 (>= 7:4.0), libavformat58 (>= 7:4.1), libavutil56 (>= 7:4.0), libdtkcore5, libdtkgui5, libdtkwidget5, libffmpegthumbnailer4v5, libgl1, libpng16-16 (>= 1.6.2-1), libportaudio2 (>= 19+svn20101113), libqt5concurrent5 (>= 5.0.2), libqt5core5a (>= 5.11.0~rc1), libqt5dbus5 (>= 5.0.2), libqt5gui5 (>= 5.8.0), libqt5network5 (>= 5.0.2), libqt5printsupport5 (>= 5.0.2), libqt5widgets5 (>= 5.2.0~alpha1), libqt5x11extras5 (>= 5.6.0), libqt5xml5 (>= 5.0.2), libsdl2-2.0-0 (>= 2.0.9), libstdc++6 (>= 7), libswresample3 (>= 7:4.0), libswscale5 (>= 7:4.0), libudev1 (>= 183), libusb-1.0-0 (>= 2:1.0.8), libv4l-0 (>= 0.5.0), zlib1g (>= 1:1.1.4), libgstreamer-plugins-base1.0-0 (>= 1.0.0), libgstreamer1.0-0 (>= 1.4.0), dde-api,
- libdwaylandclient5 | libkf5waylandclient5, 
- libdwaylandserver5 | libkf5waylandserver5
+ libavcodec58 (>= 7:4.0) | libavcodec60, libavformat58 (>= 7:4.1) | libavformat60, libavutil56 (>= 7:4.0) | libavutil58, libswresample3 (>= 7:4.0) | libswresample4, libswscale5 (>= 7:4.0) | libswscale7,
+ libdtkcore5, libdtkgui5, libdtkwidget5,  libffmpegthumbnailer4v5, libgl1, libpng16-16 (>= 1.6.2-1), libportaudio2 (>= 19+svn20101113), libqt5concurrent5 (>= 5.0.2), libqt5core5a (>= 5.11.0~rc1),
+ libqt5dbus5 (>= 5.0.2), libqt5gui5 (>= 5.8.0), libqt5network5 (>= 5.0.2), libqt5printsupport5 (>= 5.0.2), libqt5widgets5 (>= 5.2.0~alpha1), libqt5x11extras5 (>= 5.6.0), libasound2 (>= 1.0.16),
+ libqt5xml5 (>= 5.0.2), libsdl2-2.0-0 (>= 2.0.9), libstdc++6 (>= 7),  libudev1 (>= 183), libusb-1.0-0 (>= 2:1.0.8), libv4l-0 (>= 0.5.0), zlib1g (>= 1:1.1.4), libgstreamer-plugins-base1.0-0 (>= 1.0.0), libgstreamer1.0-0 (>= 1.4.0), dde-api,
+ libdwaylandclient5 | libkf5waylandclient5,  libdwaylandserver5 | libkf5waylandserver5
 Recommends: libimageeditor, uos-reporter, deepin-event-log
 Description:this package software for  UOS
  deepin-camera is a tool to view camera, and also a smart take photo and video in life.


### PR DESCRIPTION
 修复ffmpeg升级76后安装依赖报错

Log:  修复ffmpeg升级后安装依赖报错

Bug: https://pms.uniontech.com/bug-view-250209.html