### PR TITLE
fix:  修复拍摄视频出现闪退

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -2278,7 +2278,7 @@ static encoder_video_context_t *encoder_video_init_vaapi(encoder_context_t *enco
 
     video_codec_data->codec_context = getLoadLibsInstance()->m_avcodec_alloc_context3(video_codec_data->codec);
 
-    getLoadLibsInstance()->m_avcodec_get_context_defaults3(
+    getLoadLibsInstance()->m_avcodec_get_context_defaults3 && getLoadLibsInstance()->m_avcodec_get_context_defaults3(
         video_codec_data->codec_context,
         video_codec_data->codec);
 


### PR DESCRIPTION
 因ffmpeg从4升级5后API变动

Log:  修复拍摄视频出现闪退

Bug: https://pms.uniontech.com/bug-view-251245.html