### PR TITLE
fix: hardware encoder stash in 7d55

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -2204,7 +2204,7 @@ static encoder_video_context_t *encoder_video_init_vaapi(encoder_context_t *enco
 
             if (0x8086 == dev->vendor_id) {            // intel gpu support vaapi， vendor_id ：0x8086   can find from file pci.ids
                 //Iris Xe Graphics don't suppot vaapi, so softening coding.
-                if (dev->device_id == 0xa7a0) {
+                if (dev->device_id == 0xa7a0 || dev->device_id == 0x7d55) {
                     is_vaapi = HW_VAAPI_FAIL1;
                     return NULL;
                 }


### PR DESCRIPTION
mask the 7d55 for encoder

Log: make the video record use softencode

Bug: https://pms.uniontech.com/bug-view-278369.html