### PR TITLE
fix: fix fail to view video in linglong env

### DIFF
--- a/src/src/imageitem.cpp
+++ b/src/src/imageitem.cpp
@@ -350,7 +350,7 @@ void ImageItem::openFile()
             }
         } else {
             //用影院打开
-#if 1
+#if 0
             program = "ll-cli";
             arguments << "run"
                       << "org.deepin.movie"


### PR DESCRIPTION
In linglong environment, the application cannot be opened through QProcess, but can be opened through DBus.

Log: fix fail to view video in linglong env.
Bug: https://pms.uniontech.com/bug-view-282515.html