### PR TITLE
fix: 相机还原后查看设备信息

### DIFF
--- a/libcam/libcam_v4l2core/v4l2_devices.c
+++ b/libcam/libcam_v4l2core/v4l2_devices.c
@@ -294,6 +294,7 @@ int enum_v4l2_devices()
     getUdev()->m_udev_enumerate_unref(enumerate);
 
     my_device_list.num_devices = num_dev;
+    printf("my_device_list.num_devices is %d\n", num_dev);
 
     return(E_OK);
 }

--- a/src/src/devnummonitor.cpp
+++ b/src/src/devnummonitor.cpp
@@ -58,6 +58,7 @@ void DevNumMonitor::timeOutSlot()
         } else {
             m_noDevice = false;
             emit existDevice();
+            qDebug() << "existDevice!";
         }
     } else {
         m_noDevice = false;


### PR DESCRIPTION
相机还原后查看设备信息

Bug: https://pms.uniontech.com/bug-view-292759.html
Log: 相机还原后查看设备信息