### PR TITLE
refactor: remove unnecessary shell command from Camera service file

### DIFF
--- a/src/com.deepin.Camera.service
+++ b/src/com.deepin.Camera.service
@@ -1,4 +1,3 @@
-$ cat /usr/share/dbus-1/services/com.deepin.Camera.service
 [D-BUS Service]
 Name=com.deepin.Camera
 Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/deepin-camera.desktop


### PR DESCRIPTION
Remove the commented shell command from com.deepin.Camera.service file as it's not needed for the service configuration and only served as a documentation artifact.

This cleanup improves code readability while maintaining the actual D-Bus service functionality.