### PR TITLE
chore: Bump version to 6.5.16

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     camera for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.5.16) unstable; urgency=medium
+
+  * [deepin-camera] Updates for project Deepin Camera (#363)
+
+ -- renbin <renbin@uniontech.com>  Wed, 02 Apr 2025 15:47:08 +0800
+
 deepin-camera (6.5.15) unstable; urgency=medium
 
   * refactor: remove unnecessary shell command from Camera service file (#359)

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     camera for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
Bump version to 6.5.16

Log: Bump version to 6.5.16

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml files for arm64, loong64, and main configuration