### PR TITLE
fix: Update dependencies for libimageeditor in debian/control and adj…

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.16.1
+  version: 6.5.17.1
   kind: app
   description: |
     camera for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.5.17) unstable; urgency=medium
+
+  * Update version to 6.5.17
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 16 Apr 2025 16:35:23 +0800
+
 deepin-camera (6.5.16) unstable; urgency=medium
 
   * [deepin-camera] Updates for project Deepin Camera (#363)

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  qt6-tools-dev-tools,deepin-gettext-tools, qt6-svg-dev,
  libv4l-dev,libsdl2-dev,portaudio19-dev,libpng-dev,libasound2-dev,libpciaccess-dev,
  libusb-1.0-0-dev,zlib1g-dev,libudev-dev,libswscale-dev,libswresample-dev,libffmpegthumbnailer-dev,
- libx11-dev,libva-dev,libimageeditor-dev,
+ libx11-dev,libva-dev,libimageeditor6-dev,
  libgstreamer1.0-dev,libgstreamer-plugins-base1.0-dev,gstreamer1.0-plugins-good
 Standards-Version: 4.1.2
 Homepage: http://www.deepin.org
@@ -20,6 +20,6 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  libavcodec58 (>= 7:4.0) | libavcodec60, libavformat58 (>= 7:4.1) | libavformat60, libavutil56 (>= 7:4.0) | libavutil58, libswresample3 (>= 7:4.0) | libswresample4, libswscale5 (>= 7:4.0) | libswscale7, libffmpegthumbnailer4v5, libgl1, libpng16-16 (>= 1.6.2-1), libportaudio2 (>= 19+svn20101113), libgstreamer-plugins-base1.0-0 (>= 1.0.0), libgstreamer1.0-0 (>= 1.4.0)
-Recommends: libimageeditor, uos-reporter, deepin-event-log
+Recommends: libimageeditor6 | libimageeditor, uos-reporter, deepin-event-log
 Description:this package software for  UOS
  deepin-camera is a tool to view camera, and also a smart take photo and video in life.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.16.1
+  version: 6.5.17.1
   kind: app
   description: |
     camera for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.16.1
+  version: 6.5.17.1
   kind: app
   description: |
     camera for deepin os.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,12 +15,15 @@ set(TARGET_NAME deepin-camera)
 set(QT_VERSION_MAJOR 6)
 if (${QT_VERSION_MAJOR} GREATER_EQUAL 6)
     set(DTK_VERSION 6)
+    set(IMAGEVISUALRESULT_SUFFIX "6")
+else()
+    set(IMAGEVISUALRESULT_SUFFIX "")
 endif()
 
 #option (__mips__ "Use UNITTEST" ON)
 
 # cube文件目录，libvisualresult在打包时，会自动将cube文件安装到share目录下
-set(LUT_DIR "${CMAKE_INSTALL_PREFIX}/share/libimagevisualresult/filter_cube")
+set(LUT_DIR "${CMAKE_INSTALL_PREFIX}/share/libimagevisualresult${IMAGEVISUALRESULT_SUFFIX}/filter_cube")
 add_definitions(-DLUT_DIR="${LUT_DIR}")
 
 # 判断系统环境
@@ -178,7 +181,7 @@ target_include_directories(${TARGET_NAME} PUBLIC ${3rd_lib_INCLUDE_DIRS} ${PROJE
 target_link_libraries(${TARGET_NAME} ${3rd_lib_LIBRARIES}
     pthread
     dl
-    imagevisualresult
+    imagevisualresult${IMAGEVISUALRESULT_SUFFIX}
     ${LIBS}
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::Multimedia
@@ -186,7 +189,7 @@ target_link_libraries(${TARGET_NAME} ${3rd_lib_LIBRARIES}
     Qt${QT_VERSION_MAJOR}::SvgWidgets
     Qt${QT_VERSION_MAJOR}::OpenGL
     Qt${QT_VERSION_MAJOR}::OpenGLWidgets
-    )
+)
 
 include_directories("${CMAKE_INSTALL_PREFIX}/include")
 


### PR DESCRIPTION
…ust CMakeLists.txt for versioning

- Changed the dependency from libimageeditor-dev to libimageeditor6-dev in debian/control.
- Updated CMakeLists.txt to append version suffix to the imagevisualresult library path and link accordingly.

## Summary by Sourcery

Update library dependencies and CMake configuration to support Qt6 and libimageeditor6

Bug Fixes:
- Modify library linking to correctly support Qt6 version of libimageeditor

Enhancements:
- Add version suffix handling for imagevisualresult library to support multiple Qt versions

Build:
- Update CMakeLists.txt to dynamically handle library paths and linking based on Qt version