### PR TITLE
fix: Update include paths for libimagevisualresult based on QT version

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.17.1
+  version: 6.5.18.1
   kind: app
   description: |
     camera for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.5.18) unstable; urgency=medium
+
+  * Update version to 6.5.18. 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 17 Apr 2025 13:41:30 +0800
+
 deepin-camera (6.5.17) unstable; urgency=medium
 
   * Update version to 6.5.17

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.17.1
+  version: 6.5.18.1
   kind: app
   description: |
     camera for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.17.1
+  version: 6.5.18.1
   kind: app
   description: |
     camera for deepin os.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,11 @@ extern "C" {
 #endif
 
 extern "C" {
-#include <libimagevisualresult/visualresult.h>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    #include <libimagevisualresult6/visualresult.h>
+#else
+    #include <libimagevisualresult/visualresult.h>
+#endif
 }
 
 #include <DMainWindow>

--- a/src/src/filterpreviewbutton.cpp
+++ b/src/src/filterpreviewbutton.cpp
@@ -6,7 +6,11 @@
 #include "filterpreviewbutton.h"
 
 extern "C" {
-#include <libimagevisualresult/visualresult.h>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    #include <libimagevisualresult6/visualresult.h>
+#else
+    #include <libimagevisualresult/visualresult.h>
+#endif
 }
 
 #include <QPainter>

--- a/src/src/majorimageprocessingthread.cpp
+++ b/src/src/majorimageprocessingthread.cpp
@@ -8,7 +8,11 @@
 #include "camera.h"
 
 extern "C" {
-#include <libimagevisualresult/visualresult.h>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    #include <libimagevisualresult6/visualresult.h>
+#else
+    #include <libimagevisualresult/visualresult.h>
+#endif
 }
 
 #include <QFile>


### PR DESCRIPTION
- Adjusted the include statements for libimagevisualresult to conditionally include the correct header file based on the QT version.
- This change ensures compatibility with QT 6.0.0 and above by including libimagevisualresult6/visualresult.h, while maintaining support for earlier versions.

## Summary by Sourcery

Bug Fixes:
- Update include paths for libimagevisualresult to ensure compatibility with QT 6.0.0 and above.