### PR TITLE
fix: 修复相机上方边框显示一条白线

### DIFF
--- a/src/src/previewopenglwidget.cpp
+++ b/src/src/previewopenglwidget.cpp
@@ -149,6 +149,7 @@ void PreviewOpenglWidget::initializeGL()
 void PreviewOpenglWidget::resizeGL(int w, int h)
 {
     glViewport(0, 0, w, h);
+    glClearColor(0.0, 0.0, 0.0, 1.0);
     update();
 }
 


### PR DESCRIPTION
修复相机上方边框显示一条白线

Bug: https://pms.uniontech.com/bug-view-315601.html
Log: 修复相机上方边框显示一条白线

## Summary by Sourcery

Bug Fixes:
- Resolved white line display issue at the top border of the camera preview