### PR TITLE
fix: Release to unstable.

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     camera for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.5.20) unstable; urgency=medium
+
+  * Update version to 6.5.20.
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Wed, 14 May 2025 11:13:34 +0800
+
 deepin-camera (6.5.19) unstable; urgency=medium
 
   * Fix linglong build fail

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     camera for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
Release 6.5.20

Log: Release 6.5.20

## Summary by Sourcery

Prepare Debian package for version 6.5.20 release on the unstable distribution

Enhancements:
- Bump Debian package version to 6.5.20

Chores:
- Update Debian changelog entry and target release to unstable