### PR TITLE
fix: 修复4k显示卡顿

### DIFF
--- a/src/src/majorimageprocessingthread.cpp
+++ b/src/src/majorimageprocessingthread.cpp
@@ -470,7 +470,9 @@ void MajorImageProcessingThread::run()
             break;
     #endif
             //保证画面流畅的前提下降低刷新率
-            msleep(33);
+            if(m_nVdWidth <= 1920) {
+                msleep(33);
+            }
         }
 
         v4l2core_stop_stream(m_videoDevice);


### PR DESCRIPTION
修复4k显示卡顿

Bug: https://pms.uniontech.com/bug-view-316663.html
Log: 修复4k显示卡顿

## Summary by Sourcery

Bug Fixes:
- Apply frame delay only for resolutions up to 1920px to fix stuttering on 4K output.