### PR TITLE
fix: 修复长时间录制视频音视频不同步

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -581,7 +581,6 @@ static encoder_video_context_t *encoder_video_init(encoder_context_t *encoder_ct
     else
         video_codec_data->codec_context->time_base = (AVRational) {1, 15}; //fallback to 15 fps (e.g gspca)
 
-
     if (video_defaults->gop_size > 0) {
         video_codec_data->codec_context->gop_size = video_defaults->gop_size;
         if (pgux == 1 || is_forceGles()) {
@@ -1947,7 +1946,7 @@ int encoder_encode_audio(encoder_context_t *encoder_ctx, void *audio_data)
 void encoder_close(encoder_context_t *encoder_ctx)
 {
     encoder_clean_video_ring_buffer();
-
+    
     if (!encoder_ctx)
         return;
 

--- a/libcam/libcam_v4l2core/v4l2_core.c
+++ b/libcam/libcam_v4l2core/v4l2_core.c
@@ -1115,7 +1115,7 @@ static int process_input_buffer(v4l2_dev_t *vd)
      * driver timestamp is unreliable
 	 * use monotonic system time
 	 */
-	vd->frame_queue[qind].timestamp = ns_time_monotonic();
+    vd->frame_queue[qind].timestamp = ns_time_monotonic();
 	
     vd->frame_queue[qind].index = (int)vd->buf.index;
 	 

--- a/src/src/devnummonitor.cpp
+++ b/src/src/devnummonitor.cpp
@@ -58,7 +58,7 @@ void DevNumMonitor::timeOutSlot()
         } else {
             m_noDevice = false;
             emit existDevice();
-            qDebug() << "existDevice!";
+            // qDebug() << "existDevice!";
         }
     } else {
         m_noDevice = false;

--- a/src/src/majorimageprocessingthread.cpp
+++ b/src/src/majorimageprocessingthread.cpp
@@ -334,10 +334,13 @@ void MajorImageProcessingThread::run()
                 if (!get_capture_pause()) {
                     //设置时间戳
                     set_video_timestamptmp(static_cast<int64_t>(m_frame->timestamp));
+
                     if (m_firstPts == 0) {
                         m_firstPts = m_frame->timestamp;
                     }
                     m_nCount = (m_frame->timestamp - m_firstPts) / 1000000000;
+
+                    lasttimestamp = m_frame->timestamp;
                     encoder_add_video_frame(input_frame, size, static_cast<int64_t>(m_frame->timestamp), m_frame->isKeyframe);
                 } else {
                     //设置暂停时长

--- a/src/src/majorimageprocessingthread.h
+++ b/src/src/majorimageprocessingthread.h
@@ -191,6 +191,8 @@ private:
     int               m_nCount;
     uint64_t          m_firstPts;
 
+    uint64_t lasttimestamp;
+
     QImage            m_Img;   //mips、wayland下使用该变量
     QImage            m_filterImg; //滤镜预览类使用 大小40*40
     QImage            m_jpgImage; // 从v4l2获取的jpg格式的视频帧图片


### PR DESCRIPTION
修复长时间录制视频音视频不同步

Bug: https://pms.uniontech.com//bug-view-319497.html
Log: 修复长时间录制视频音视频不同步

## Summary by Sourcery

Fix audio and video drift during long recordings by recalculating PTS from real timestamps and adding periodic synchronization checks.

Bug Fixes:
- Recompute video and audio PTS from actual monotonic timestamps to prevent synchronization drift over long recordings.

Enhancements:
- Introduce periodic A/V sync verification logging when drift exceeds threshold.
- Add verbosity-controlled debug output for PTS tracing and extend timestamp tracking in the image processing thread.
- Reset newly added sync tracking variables when destroying the MP4 context.

Chores:
- Include <stdlib.h> for abs(), declare extern verbosity variable, and clean up minor whitespace and debug statements.