### PR TITLE
fix: 移除摄像头8k分辨率限制

### DIFF
--- a/libcam/libcam_v4l2core/frame_decoder.c
+++ b/libcam/libcam_v4l2core/frame_decoder.c
@@ -99,7 +99,7 @@ int alloc_v4l2_frames(v4l2_dev_t *vd)
 					exit(-1);
 				}
 
-                vd->frame_queue[i].yuv_frame = calloc((uint8_t)framesizeIn, sizeof(uint8_t));
+                vd->frame_queue[i].yuv_frame = calloc((size_t)framesizeIn, sizeof(uint8_t));
 				if(vd->frame_queue[i].yuv_frame == NULL)
 				{
 					fprintf(stderr, "V4L2_CORE: FATAL memory allocation failure (alloc_v4l2_frames): %s\n", strerror(errno));
@@ -108,7 +108,7 @@ int alloc_v4l2_frames(v4l2_dev_t *vd)
 
 			}
 
-            vd->h264_last_IDR = calloc((uint8_t)(width * height), sizeof(uint8_t));
+            vd->h264_last_IDR = calloc((size_t)(width * height), sizeof(uint8_t));
 			if(vd->h264_last_IDR == NULL)
 			{
 				fprintf(stderr, "V4L2_CORE: FATAL memory allocation failure (alloc_v4l2_frames): %s\n", strerror(errno));

--- a/src/src/Settings.cpp
+++ b/src/src/Settings.cpp
@@ -114,8 +114,6 @@ void Settings::setNewResolutionList()
             for (int i = 0 ; i < list_stream_formats[format_index].numb_res; i++) {
                 if ((list_stream_formats[format_index].list_stream_cap[i].width > 0
                         && list_stream_formats[format_index].list_stream_cap[i].height > 0) &&
-                        (list_stream_formats[format_index].list_stream_cap[i].width < 7680
-                         && list_stream_formats[format_index].list_stream_cap[i].height < 4320) &&
                         ((list_stream_formats[format_index].list_stream_cap[i].width % 8) == 0
                          && (list_stream_formats[format_index].list_stream_cap[i].width % 16) == 0
                          && (list_stream_formats[format_index].list_stream_cap[i].height % 8) ==  0)) {

--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -1109,8 +1109,6 @@ void CMainWindow::settingDialog()
 
                 if ((list_stream_formats[format_index].list_stream_cap[i].width > 0
                         && list_stream_formats[format_index].list_stream_cap[i].height > 0) &&
-                        (list_stream_formats[format_index].list_stream_cap[i].width < 7680
-                         && list_stream_formats[format_index].list_stream_cap[i].height < 4320) &&
                         ((list_stream_formats[format_index].list_stream_cap[i].width % 8) == 0
                          && (list_stream_formats[format_index].list_stream_cap[i].width % 16) == 0
                          && (list_stream_formats[format_index].list_stream_cap[i].height % 8) ==  0)) {

--- a/src/src/videowidget.h
+++ b/src/src/videowidget.h
@@ -414,6 +414,8 @@ private:
     */
     int switchCamera(const char *device, const char *devName);
 
+    int getUSBCameraGroup(v4l2_device_list_t *devlist, QVector<QPair<QString, QVector<v4l2_dev_sys_data_t *> > > &vGroupData);
+
     /**
      * @brief getSaveFilePrefix
      * @return UOS_ 专业版 DEEPIN_ 社区版 CAMERA_ 其他


### PR DESCRIPTION
移除摄像头8k分辨率限制

Log: 移除摄像头8k分辨率限制
Bug: https://pms.uniontech.com//bug-view-320983.html

## Summary by Sourcery

Remove the hard limit on 8K camera resolutions, enhance USB camera switching by grouping devices by location, and fix buffer allocation size computations in the V4L2 frame decoder.

Bug Fixes:
- Fix calloc parameter types in the V4L2 frame decoder to use correct size_t sizes for buffer allocations.

Enhancements:
- Allow listing and selecting resolutions at or above 8K by removing the previous width/height cap.
- Group USB cameras by physical location and update the device-switching logic to handle multiple camera groups.