### PR TITLE
fix: Improve close button visibility when USB camera is connected

### DIFF
--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -1255,6 +1255,11 @@ void CMainWindow::loadAfterShow()
     m_windowStateThread = new windowStateThread(m_bWayland, this);
     connect(m_windowStateThread, &windowStateThread::someWindowFullScreen, this, &CMainWindow::onStopPhotoAndRecord);
 
+    QTimer::singleShot(100, this, [=](){
+        resize(this->size() + QSize(1, 1));
+        resize(this->size() + QSize(-1, -1));
+    });
+
     QJsonObject obj{
         {"tid", EventLogUtils::Start},
         {"mode", 1},


### PR DESCRIPTION
Fixed unclear color rendering of the camera app's window close button (top-right corner) after connecting a USB camera by triggering an additional resize event to refresh the display.

Log: Fix close button display issue with USB cameras
Bug: https://pms.uniontech.com/bug-view-328323.html

## Summary by Sourcery

Bug Fixes:
- Post a QResizeEvent after a brief delay to refresh the window and fix close button visibility with USB cameras