### PR TITLE
fix: Improve audio-video sync compatibility in camera recording

### DIFF
--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -592,6 +592,8 @@ static encoder_video_context_t *encoder_video_init(encoder_context_t *encoder_ct
     switch (video_defaults->codec_id) {
     case AV_CODEC_ID_H264: {
         video_codec_data->codec_context->me_range = 16;
+        video_codec_data->codec_context->gop_size = 250;
+        video_codec_data->codec_context->max_b_frames = 0;
         //av_dict_set(&video_codec_data->private_options, "rc_lookahead", "1", 0);
         getAvutil()->m_av_dict_set(&video_codec_data->private_options, "crf", "23", 0);
         getAvutil()->m_av_dict_set(&video_codec_data->private_options, "preset", "ultrafast", 0);


### PR DESCRIPTION
Optimized encoding parameters by increasing GOP size and reducing encoding latency, with adjusted B-frame count for better synchronization.

Log: Enhance AV sync through encoding optimization
Bug: https://pms.uniontech.com/task-view-380589.html

## Summary by Sourcery

Optimize camera recording encoding settings to improve audio-video synchronization by fixing the keyframe interval and disabling B-frames.

Enhancements:
- Set the video encoder GOP size to a fixed value of 250 for consistent keyframe intervals
- Disable B-frames by setting max_b_frames to 0 to reduce encoding latency and improve sync