### PR TITLE
fix: Optimize ISP device filtering for better camera compatibility

### DIFF
--- a/src/assets/org.deepin.camera.encode.json
+++ b/src/assets/org.deepin.camera.encode.json
@@ -1,26 +1,36 @@
 {
-  "magic": "dsg.config.meta",
-  "version": "1.0",
-  "contents": {
-      "mp4EncodeMode": {
-          "value": -1,
-          "serial": 0,
-          "flags": ["global"],
-          "name": "pugx mp4 code mode",
-          "name[zh_CN]": "特殊编码模式",
-          "description": "pugx mp4 code mode",
-          "permissions": "readwrite",
-          "visibility": "private"
-      },
-      "forceGles": {
-        "value": -1,
-        "serial": 0,
-        "flags": ["global"],
-        "name": "forc elgs show in wayland",
-        "name[zh_CN]": "在 wayland 下特殊显示模式",
-        "description": "special mode do use gles to show",
-        "permissions": "readwrite",
-        "visibility": "private"
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "mp4EncodeMode": {
+            "value": -1,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "pugx mp4 code mode",
+            "name[zh_CN]": "特殊编码模式",
+            "description": "pugx mp4 code mode",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "forceGles": {
+            "value": -1,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "forc elgs show in wayland",
+            "name[zh_CN]": "在 wayland 下特殊显示模式",
+            "description": "special mode do use gles to show",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "projectID": {
+            "value": "",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "project ID",
+            "name[zh_CN]": "不同项目下的定制内容",
+            "description": "Customized content under different projects",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
     }
-  }
 }


### PR DESCRIPTION
Implemented intelligent ISP device filtering to improve camera device compatibility:
- Keep useful ISP output devices (mainpath) that support standard video formats
- Filter out problematic devices (/dev/video12) with hardware issues
- Remove useless ISP pipeline nodes (statistics, params, selfpath)
- Add detailed logging for device filtering decisions

This ensures better camera enumeration while maintaining support for advanced
hardware features like NV12 encoding on ISP devices.

Log: Optimize camera device filtering with intelligent ISP handling
Bug: @https://pms.uniontech.com/task-view-380629.html

## Summary by Sourcery

Optimize V4L2 device enumeration by implementing intelligent ISP filtering to enhance camera compatibility

Enhancements:
- Add ISP device filtering to exclude problematic hardware endpoints (e.g., /dev/video12)
- Retain only useful ISP output devices (mainpath) and remove statistical, parameter, and selfpath nodes
- Introduce detailed logging for each ISP filtering decision