### PR TITLE
feat: Add project-specific device filtering control

### DIFF
--- a/libcam/libcam/camview.c
+++ b/libcam/libcam/camview.c
@@ -114,6 +114,7 @@ static char status_message[80];
 
 static int encode_thread_running = 0;
 
+static char project_id[200];
 
 void set_video_time_capture(double video_time)
 {
@@ -1381,4 +1382,19 @@ void set_pugx_status(int status)
 int get_pugx_status()
 {
     return is_pgux;
+}
+
+void set_project_id(const char *id)
+{
+    if (id != NULL) {
+        memset(project_id, 0, sizeof(project_id));
+        strncpy(project_id, id, sizeof(project_id) - 1);
+    } else {
+        memset(project_id, 0, sizeof(project_id));
+    }
+}
+
+const char* get_project_id(void)
+{
+    return project_id;
 }

--- a/libcam/libcam/camview.h
+++ b/libcam/libcam/camview.h
@@ -34,6 +34,7 @@ extern "C" {
 #define VERTEXIN 0
 #define TEXTUREIN 1
 
+#define UOS2025073011543 "UOS2025073011543"
 typedef struct _capture_loop_data_t {
     void *options;
     void *config;
@@ -438,6 +439,30 @@ int get_pugx_status();
 void set_forceGles(int status);
 
 int is_forceGles();
+
+/*
+ * set project id
+ * args:
+ *    project_id - project id string
+ *
+ * asserts:
+ *    none
+ *
+ * returns: none
+ */
+void set_project_id(const char *project_id);
+
+/*
+ * get project id
+ * args:
+ *    none
+ *
+ * asserts:
+ *    none
+ *
+ * returns: pointer to project id string
+ */
+const char* get_project_id(void);
 
 #ifdef __cplusplus
 }

--- a/libcam/libcam_v4l2core/v4l2_devices.c
+++ b/libcam/libcam_v4l2core/v4l2_devices.c
@@ -345,14 +345,17 @@ int enum_v4l2_devices()
             continue; /*next dir entry*/
         }
         
-        // 检查是否为标准摄像头设备，过滤掉ISP管道设备
-        if (!is_standard_camera_device(fd, &v4l2_cap, v4l2_device)) {
-            if (verbosity > 0) {
-                fprintf(stderr, "V4L2_CORE: ignore device %s - not a standard camera (driver: %s, card: %s)\n", 
-                       v4l2_device, v4l2_cap.driver, v4l2_cap.card);
+        // when project_id equals UOS2025073011543 filter out ISP devices
+        const char* current_project_id = get_project_id();
+        if (current_project_id != NULL && strcmp(current_project_id, UOS2025073011543) == 0) {
+            if (!is_standard_camera_device(fd, &v4l2_cap, v4l2_device)) {
+                if (verbosity > 0) {
+                    fprintf(stderr, "V4L2_CORE: ignore device %s - not a standard camera (driver: %s, card: %s) [project_id: %s]\n", 
+                           v4l2_device, v4l2_cap.driver, v4l2_cap.card, current_project_id);
+                }
+                getV4l2()->m_v4l2_close(fd);
+                continue; /*next dir entry*/
             }
-            getV4l2()->m_v4l2_close(fd);
-            continue; /*next dir entry*/
         }
 #endif
         getV4l2()->m_v4l2_close(fd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,50 +121,56 @@ int main(int argc, char *argv[])
         format.setRenderableType(QSurfaceFormat::OpenGLES);
         format.setDefaultFormat(format);
         set_wayland_status(1);
-
-        int mp4Encode = -1;
-#ifdef DTKCORE_CLASS_DConfigFile
-        //需要查询是否对X机型设置MP4编码缓存特殊处理
-        DConfig *dconfig = DConfig::create("org.deepin.camera", "org.deepin.camera.encode");
-        if (dconfig && dconfig->isValid() && dconfig->keyList().contains("mp4EncodeMode")) {
-            mp4Encode = dconfig->value("mp4EncodeMode").toInt();
-            set_pugx_status(mp4Encode);
-        }
-
-        int forceGles = -1;
-        if (dconfig && dconfig->isValid() && dconfig->keyList().contains("forceGles")) {
-            forceGles = dconfig->value("forceGles").toInt();
-            set_forceGles(forceGles);
-        }
-#endif
-        qInfo() << "mp4EncodeMode value is:" << get_pugx_status();
-        if (mp4Encode == -1) {
-            //判断是否是X机型
-            QStringList options;
-            options << QString(QStringLiteral("-c"));
-            options << QString(QStringLiteral("dmidecode -t 11 | grep 'String 4' | awk '{print $NF}' && "
-                                              "dmidecode -s system-product-name|awk '{print $NF}'"));
-            QProcess process;
-            process.start(QString(QStringLiteral("bash")), options);
-            process.waitForFinished();
-            process.waitForReadyRead();
-            QByteArray tempArray = process.readAllStandardOutput();
-            char *charTemp = tempArray.data();
-            QString str_output = QString(QLatin1String(charTemp));
-            process.close();
-
-            if (str_output.contains("PGUX", Qt::CaseInsensitive)) {
-                mp4Encode = 1;
-                qDebug() << "this is PGUX";
-            } else {
-                mp4Encode = 0;
-            }
-            qInfo() << "process find mp4EncodeMode value is:" << get_pugx_status();
-        }
-
-        set_pugx_status(mp4Encode);
-        qInfo() << "last mp4EncodeMode value is:" << get_pugx_status();
     }
+    int mp4Encode = -1;
+#ifdef DTKCORE_CLASS_DConfigFile
+    //需要查询是否对X机型设置MP4编码缓存特殊处理
+    DConfig *dconfig = DConfig::create("org.deepin.camera", "org.deepin.camera.encode");
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("mp4EncodeMode")) {
+        mp4Encode = dconfig->value("mp4EncodeMode").toInt();
+        set_pugx_status(mp4Encode);
+    }
+
+    int forceGles = -1;
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("forceGles")) {
+        forceGles = dconfig->value("forceGles").toInt();
+        set_forceGles(forceGles);
+    }
+
+    QString projectId = "";
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("projectID")) {
+        projectId = dconfig->value("projectID").toString();
+        set_project_id(projectId.toUtf8().constData());
+    }
+#endif
+    qInfo() << "mp4EncodeMode value is:" << get_pugx_status();
+    qInfo() << "projectID value is:" << get_project_id();
+    if (mp4Encode == -1) {
+        //判断是否是X机型
+        QStringList options;
+        options << QString(QStringLiteral("-c"));
+        options << QString(QStringLiteral("dmidecode -t 11 | grep 'String 4' | awk '{print $NF}' && "
+                                          "dmidecode -s system-product-name|awk '{print $NF}'"));
+        QProcess process;
+        process.start(QString(QStringLiteral("bash")), options);
+        process.waitForFinished();
+        process.waitForReadyRead();
+        QByteArray tempArray = process.readAllStandardOutput();
+        char *charTemp = tempArray.data();
+        QString str_output = QString(QLatin1String(charTemp));
+        process.close();
+
+        if (str_output.contains("PGUX", Qt::CaseInsensitive)) {
+            mp4Encode = 1;
+            qDebug() << "this is PGUX";
+        } else {
+            mp4Encode = 0;
+        }
+        qInfo() << "process find mp4EncodeMode value is:" << get_pugx_status();
+    }
+
+    set_pugx_status(mp4Encode);
+    qInfo() << "last mp4EncodeMode value is:" << get_pugx_status();
 
     QTime time;
     time.start();


### PR DESCRIPTION
- Add projectID configuration support in main.cpp
  * Read projectID from DConfig configuration
  * Initialize project_id via set_project_id() function

- Implement project_id management functions in camview
  * Add set_project_id() and get_project_id() in camview.h/c
  * Use safe string operations with boundary checks
  * Store project_id in static buffer for global access

- Add conditional device filtering in v4l2_devices.c
  * Enable ISP device filtering only when projectID="UOS2025073011543"
  * Maintain backward compatibility for other configurations
  * Enhance logging with project_id information

Log: This allows project-specific control of camera device filtering
Task: https://pms.uniontech.com/task-view-380629.html

## Summary by Sourcery

Add project-specific device filtering by reading and storing a projectID from configuration, exposing setter/getter functions, and conditionally filtering ISP devices based on the projectID.

New Features:
- Read projectID from DConfig in main.cpp and initialize it via set_project_id
- Add set_project_id and get_project_id functions in camview for global project ID management
- Enable conditional filtering of ISP devices in v4l2_devices when projectID equals "UOS2025073011543"

Enhancements:
- Log the projectID value alongside existing mp4EncodeMode logs