### PR TITLE
chore: Update linglong base and runtime

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     camera for deepin os.
 
-base: org.deepin.base/25.2.0/arm64
-runtime: org.deepin.runtime.dtk/25.2.0/arm64
+base: org.deepin.base/25.2.1/arm64
+runtime: org.deepin.runtime.dtk/25.2.1/arm64
 
 command:
   - deepin-camera

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.5.33) unstable; urgency=medium
+
+  * chore: Update linglong base and runtime
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 17 Sep 2025 11:15:21 +0800
+
 deepin-camera (6.5.32) unstable; urgency=medium
 
   * Update version to 6.5.32. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     camera for deepin os.
 
-base: org.deepin.base/25.2.0
-runtime: org.deepin.runtime.dtk/25.2.0
+base: org.deepin.base/25.2.1
+runtime: org.deepin.runtime.dtk/25.2.1
 
 command:
   - deepin-camera

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     camera for deepin os.
 
-base: org.deepin.base/25.2.0/loong64
-runtime: org.deepin.runtime.dtk/25.2.0/loong64
+base: org.deepin.base/25.2.1/loong64
+runtime: org.deepin.runtime.dtk/25.2.1/loong64
 
 command:
   - deepin-camera


### PR DESCRIPTION
Update linglong base and runtime

Log: Update linglong base and runtime

## Summary by Sourcery

Bump deepin-camera version and update Linglong base and runtime dependencies to 25.2.1 across supported architectures

Chores:
- Upgrade deepin-camera package version to 6.5.33.1 in linglong manifests
- Update Linglong base and runtime references from 25.2.0 to 25.2.1 for arm64, loong64, and default architectures