### PR TITLE
refactor(video): change default video format to webm

### DIFF
--- a/src/src/Settings.cpp
+++ b/src/src/Settings.cpp
@@ -54,12 +54,8 @@ void Settings::init()
     if (DataManager::instance()->encodeEnv() == FFmpeg_Env) {
         if (DataManager::instance()->encExists()) {
             GlobalUtils::loadCameraConf();
-            if (!GlobalUtils::isLowPerformanceBoard()) {
-                videoFormatList << tr("mp4") << tr("webm");
-            } else {
-                videoFormatList << tr("webm") << tr("mp4");
-            }
-
+            // webm 作为默认格式（索引0），mp4 作为备选（索引1）
+            videoFormatList << tr("webm") << tr("mp4");
         } else {
             videoFormatList << tr("webm");
             m_settings->setOption("outsetting.outformat.vidformat", 0);

--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -222,14 +222,17 @@ videowidget::videowidget(DWidget *parent)
     // 默认不显示网格线
     setGridType(Grid_None);
 
-    if (DataManager::instance()->encodeEnv() != FFmpeg_Env || !DataManager::instance()->encExists() || GlobalUtils::isLowPerformanceBoard()) {
+    // 默认使用 webm 格式
+    if (DataManager::instance()->encodeEnv() != FFmpeg_Env || !DataManager::instance()->encExists()) {
         m_videoFormat = "webm";
-    }
-    if (dc::Settings::get().getOption("outsetting.outformat.vidformat").toInt()) {
-        if (!GlobalUtils::isLowPerformanceBoard())
-            m_videoFormat = "webm";
-        else
+    } else {
+        // 根据配置选择格式：0=webm(默认), 1=mp4
+        int formatIndex = dc::Settings::get().getOption("outsetting.outformat.vidformat").toInt();
+        if (formatIndex == 1) {
             m_videoFormat = "mp4";
+        } else {
+            m_videoFormat = "webm";
+        }
     }
 }
 


### PR DESCRIPTION
Unify video format selection logic across all devices. Change default format from mp4 to webm for better compatibility.

统一所有设备的视频格式选择逻辑，将默认格式从 mp4 改为 webm 以提升兼容性。

Log: 修改默认录制视频格式为 webm
PMS: https://pms.uniontech.com/bug-view-358869.html
Influence: 新用户默认使用 webm 格式录制视频，用户仍可在设置中切换为 mp4。已有用户配置不受影响。

## Summary by Sourcery

Enhancements:
- Standardize video format selection so WebM is the default format with MP4 as an optional alternative in settings.