### PR TITLE
chore: bump version 6.0.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-camera (6.0.13) unstable; urgency=medium
+
+  * tag 6.0.13
+
+-- zhangjiarui <zhangjiarui@uniontech.com>  Thu, 30 Apr 2026 11:36:13 +0800
+
 deepin-camera (6.0.12) unstable; urgency=medium
 
   * tag 6.0.12


### PR DESCRIPTION
bump version

Log: bump version

## Summary by Sourcery

Build:
- Bump Debian changelog version to 6.0.13 for packaging.