### PR TITLE
fix(ui): set icon opacity for photo mode buttons in takePhotoSettingA…

### DIFF
--- a/src/src/takephotosettingareawidget.cpp
+++ b/src/src/takephotosettingareawidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -1545,6 +1545,10 @@ void takePhotoSettingAreaWidget::setState(bool bPhoto)
         m_flashlightUnfoldBtn->setOpacity(102);
         m_filtersUnfoldBtn->setOpacity(102);
         m_exposureBtn->setOpacity(102);
+        m_flashlightUnfoldBtn->setIconOpacity(1);
+        m_delayUnfoldBtn->setIconOpacity(1);
+        m_filtersUnfoldBtn->setIconOpacity(1);
+        m_exposureBtn->setIconOpacity(1);
     } else {
         m_flashlightUnfoldBtn->setVisible(false);
         m_filtersUnfoldBtn->setVisible(false);


### PR DESCRIPTION
…reaWidget

Add setIconOpacity(1) calls for flashlight, delay, filters, and exposure buttons when entering photo mode to restore correct visual state

修复(ui): 拍照模式下恢复按钮图标透明度状态

进入拍照模式时对闪光灯、延迟拍摄、滤镜、曝光按钮调用 setIconOpacity(1)， 恢复按钮图标正常透明度显示

Log: 修复拍照模式按钮图标透明度异常
Bug: https://pms.uniontech.com/bug-view-196565.html

## Summary by Sourcery

Bug Fixes:
- Fix incorrect icon opacity for flashlight, delay, filters, and exposure buttons in photo mode.