### PR TITLE
fix(ui): remove transparent separator lines between filter buttons in…

### DIFF
--- a/src/src/filterpreviewbutton.cpp
+++ b/src/src/filterpreviewbutton.cpp
@@ -16,7 +16,7 @@ extern "C" {
 
 DWIDGET_USE_NAMESPACE;
 
-#define MARGIN 5
+#define MARGIN 6
 #define IMAGE_SIZE 40
 #define BUTTON_SIZE (IMAGE_SIZE + MARGIN * 2)
 

--- a/src/src/takephotosettingareawidget.cpp
+++ b/src/src/takephotosettingareawidget.cpp
@@ -152,7 +152,7 @@ void takePhotoSettingAreaWidget::initButtons()
     m_scrollAreaWidget->setAttribute(Qt::WA_TranslucentBackground, true);
     QVBoxLayout *scrollLayout = new QVBoxLayout(m_scrollAreaWidget);
     scrollLayout->setContentsMargins(0, 0, 0, 0);
-    scrollLayout->setSpacing(2);
+    scrollLayout->setSpacing(0);
     m_scrollAreaWidget->setLayout(scrollLayout);
     m_scrollArea = new QScrollArea(this);
     m_scrollArea->setFrameShape(QFrame::NoFrame);


### PR DESCRIPTION
… photo setting area

  - Change scrollLayout spacing from 2px to 0px to eliminate visible gaps between filter preview buttons
  - The 2px spacing combined with WA_TranslucentBackground caused the underlying viewport background to show through, creating transparent separator lines between each filter option

  修复(ui): 去掉拍照设置区域滤镜按钮之间的透明分割线

  - 将 scrollLayout 间距从 2px 改为 0px，消除滤镜预览按钮之间的可见间隙
  - 2px 间距与 WA_TranslucentBackground 配合导致下层 viewport 背景透出，在每个滤镜选项之间形成透明分割线

  Log: 去掉滤镜选择面板中各滤镜之间的透明分割线，将 QVBoxLayout 间距从 2px 改为 0px
  Bug: https://pms.uniontech.com/bug-view-160651.html