### PR TITLE
fix: 修复摄像头重连和重启后分辨率恢复默认值

### DIFF
--- a/src/src/Settings.cpp
+++ b/src/src/Settings.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -155,17 +155,23 @@ void Settings::setNewResolutionList()
 
             for (int i = 0; i < resolutionDatabase.size(); i++) {
                 QStringList resolutiontemp = resolutionDatabase[i].split("x");
-                if ((v4l2core_get_frame_width(get_v4l2_device_handler()) == resolutiontemp[0].toInt()) &&
-                        (v4l2core_get_frame_height(get_v4l2_device_handler()) == resolutiontemp[1].toInt())) {
+                if (resolutiontemp.size() >= 2 &&
+                        v4l2core_get_frame_width(get_v4l2_device_handler()) == resolutiontemp[0].toInt() &&
+                        v4l2core_get_frame_height(get_v4l2_device_handler()) == resolutiontemp[1].toInt()) {
                     defres = i; //set selected resolution index
                     break;
                 }
             }
-
+            // 抑制中间态的 resolutionchanged, 仅在最后发射一次正确值
+            m_updatingResolution = true;
             resolutionmodeFamily->setData("items", resolutionDatabase);
-
-            //设置当前分辨率的索引
             m_settings->setOption(QString("outsetting.resolutionsetting.resolution"), defres);
+            QTimer::singleShot(0, this, [this, resolutionDatabase, defres]() {
+                m_updatingResolution = false;
+                if (defres >= 0 && defres < resolutionDatabase.size()) {
+                    emit resolutionchanged(resolutionDatabase[defres]);
+                }
+            });
         } else {
             resolutionDatabase.clear();
             resolutionDatabase.append(QString(tr("None")));
@@ -222,6 +228,8 @@ QVariant Settings::getBackOption(const QString &opt)
 void Settings::onValueChanged(const QString & key, const QVariant & value)
 {
     if (key.startsWith("outsetting.resolutionsetting.resolution")) {
+        if (m_updatingResolution)
+            return;
         auto mode_opt = m_settings->option("outsetting.resolutionsetting.resolution");
         if (value >= 0 && mode_opt->data("items").toStringList().size() > value.toInt()) {
             QString mode = mode_opt->data("items").toStringList()[value.toInt()];

--- a/src/src/Settings.h
+++ b/src/src/Settings.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -160,6 +160,7 @@ private:
     QString             m_configPath;
     QPointer<DSettings> m_settings;
     QSettingBackend*    m_backend;
+    bool                m_updatingResolution = false;
 };
 
 }

--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -1148,15 +1148,21 @@ void CMainWindow::settingDialog()
 
             }
 
-            for (int i = 0; i < resolutionDatabase.size(); i++) {
-                QStringList resolutiontemp = resolutionDatabase[i].split("x");
+            int savedRes = resolutionmodeFamily->value().toInt();
+            if (savedRes >= 0 && savedRes < resolutionDatabase.size()) {
+                defres = savedRes;
+            } else {
+                for (int i = 0; i < resolutionDatabase.size(); i++) {
+                    QStringList resolutiontemp = resolutionDatabase[i].split("x");
 
-                if ((v4l2core_get_frame_width(get_v4l2_device_handler()) == resolutiontemp[0].toInt()) &&
-                        (v4l2core_get_frame_height(get_v4l2_device_handler()) == resolutiontemp[1].toInt())) {
-                    defres = i; //设置分辨率下拉菜单当前索引
-                    break;
+                    if (resolutiontemp.size() >= 2 &&
+                            v4l2core_get_frame_width(get_v4l2_device_handler()) == resolutiontemp[0].toInt() &&
+                            v4l2core_get_frame_height(get_v4l2_device_handler()) == resolutiontemp[1].toInt()) {
+                        defres = i; //设置分辨率下拉菜单当前索引
+                        break;
+                    }
+
                 }
-
             }
 
             resolutionmodeFamily->setData("items", resolutionDatabase);
@@ -1994,6 +2000,7 @@ void CMainWindow::initRightButtons()
     connect(&m_fileWatcherUp, SIGNAL(fileChanged(const QString &)), this, SLOT(onDirectoryChanged(const QString &)));
     //摄像头切换成功信号
     connect(m_videoPre, SIGNAL(switchCameraSuccess(const QString &)), this, SLOT(onSwitchCameraSuccess(const QString &)));
+    connect(m_videoPre, SIGNAL(switchCameraSuccess(const QString &)), &Settings::get(), SLOT(setNewResolutionList()));
     locateRightButtons();
 }
 

--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -1217,9 +1217,7 @@ int videowidget::switchCamera(const char *device, const char *devName)
         m_imgPrcThread->start();
         DataManager::instance()->setdevStatus(CAM_CANUSE);
         //切换摄像机成功，发送设备名称信号到主界面。
-        if (devName && strlen(devName)) {
-            emit switchCameraSuccess(devName);
-        }
+        emit switchCameraSuccess(devName ? devName : "");
         dc::Settings::get().setBackOption("device", device);
     } else if (ret == E_FORMAT_ERR) {
         v4l2_dev_t *vd =  get_v4l2_device_handler();


### PR DESCRIPTION
  ON 阶段 setData 触发 DTK widget 重建时读到 OFF 阶段清零的 value=0，
  中间态的 resolutionchanged 异步将相机切到错误分辨率，settingDialog 重新打开时
  以相机当前错误分辨率覆盖了已保存的用户选择。

  - ON 分支用 m_updatingResolution 标志抑制 setData/setOption 的中间态信号， QTimer::singleShot 在所有排队信号处理后发射一次正确值
  - settingDialog 优先读 option 已保存值，设备分辨率作为 fallback
  - switchCameraSuccess 连接 setNewResolutionList，启动和重连均触发 ON 分支恢复
  - switchCameraSuccess 无条件发射，构造函数路径也能进入 ON 分支

  Log: 修复摄像头重连和应用重启后分辨率恢复为默认值
  Bug: https://pms.uniontech.com/bug-view-363077.html