### PR TITLE
fix: 修复 setNewResolutionList 排序不一致导致分辨率索引错位

### DIFF
--- a/src/src/Settings.cpp
+++ b/src/src/Settings.cpp
@@ -136,8 +136,8 @@ void Settings::setNewResolutionList()
                     QStringList resolutiontemp1 = resolutionDatabase[j].split("x");
                     QStringList resolutiontemp2 = resolutionDatabase[j + 1].split("x");
 
-                    if ((resolutiontemp1[0].toInt() <= resolutiontemp2[0].toInt())
-                            || (resolutiontemp1[1].toInt() < resolutiontemp2[1].toInt())) {
+                    if ((resolutiontemp1[0].toInt() < resolutiontemp2[0].toInt()) ||
+                            (resolutiontemp1[0].toInt() == resolutiontemp2[0].toInt() && (resolutiontemp1[1].toInt() < resolutiontemp2[1].toInt()))) {
                         QString resolutionstr = resolutionDatabase[j + 1];
                         resolutionDatabase[j + 1] = resolutionDatabase[j];
                         resolutionDatabase[j] = resolutionstr;


### PR DESCRIPTION
setNewResolutionList 排序条件使用了 <=，相同宽度时无条件交换，
  导致排序结果与 settingDialog 不一致。摄像头重连后保存的索引值
  在重新打开设置界面时映射到了错误的分辨率（如 640x480 显示为 640x360）。

Log: 修复 setNewResolutionList 排序不一致导致分辨率索引错位
Bug: https://pms.uniontech.com/bug-view-363077.html

## Summary by Sourcery

Bug Fixes:
- Fix resolution sorting comparison so resolutions with the same width are ordered by height, avoiding index mismatches after camera reconnection.