### PR TITLE
fix(config): support low performance device config

### DIFF
--- a/src/assets/org.deepin.camera.encode.json
+++ b/src/assets/org.deepin.camera.encode.json
@@ -111,6 +111,16 @@
             "description": "Set preferred resolution",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "isLowPerformanceDevice": {
+            "value": false,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "is low performance device",
+            "name[zh_CN]": "是否是低性能设备",
+            "description": "Is low performance device",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/src/globalutils.cpp
+++ b/src/src/globalutils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -11,11 +11,17 @@
 #include <QDBusArgument>
 #include <QDBusReply>
 
+#ifdef DTKCORE_CLASS_DConfigFile
+#include <DConfig>
+#include <memory>
+#endif
+
 // 相机配置文件
 const QString CAMERA_CONF_PATH = "/usr/share/deepin-camera/camera.conf";
 #define LOW_PERFORMANCE_BOARD "LowPerformanceBoard"
 
 QStringList GlobalUtils::m_LowPerformanceBoards = QStringList();
+bool GlobalUtils::m_IsLowPerformanceDevice = false;
 
 struct DMIInfo {
     QString biosManufacturer;
@@ -56,6 +62,12 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, DMIInfo &mystruct
 
 bool GlobalUtils::isLowPerformanceBoard()
 {
+#ifdef DTKCORE_CLASS_DConfigFile
+    if (m_IsLowPerformanceDevice) {
+        return true;
+    }
+#endif
+
     qDBusRegisterMetaType<DMIInfo>();
     QDBusInterface *monitorInterface = new QDBusInterface("com.deepin.system.SystemInfo", "/com/deepin/system/SystemInfo", "org.freedesktop.DBus.Properties", QDBusConnection::systemBus());
     if (!monitorInterface->isValid())
@@ -86,4 +98,13 @@ void GlobalUtils::loadCameraConf()
     } else {
         m_LowPerformanceBoards = QStringList();
     }
+
+#ifdef DTKCORE_CLASS_DConfigFile
+    m_IsLowPerformanceDevice = false;
+    std::unique_ptr<DTK_CORE_NAMESPACE::DConfig> dconfig(
+        DTK_CORE_NAMESPACE::DConfig::create("org.deepin.camera", "org.deepin.camera.encode"));
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("isLowPerformanceDevice")) {
+        m_IsLowPerformanceDevice = dconfig->value("isLowPerformanceDevice").toBool();
+    }
+#endif
 }

--- a/src/src/globalutils.h
+++ b/src/src/globalutils.h
@@ -19,6 +19,7 @@ public:
 
 private:
     static QStringList m_LowPerformanceBoards;
+    static bool m_IsLowPerformanceDevice;
 };
 
 #endif // GLOBALUTILS_H


### PR DESCRIPTION
Log: 支持通过配置标记低性能设备
Bug: https://pms.uniontech.com/bug-view-358869.html
Influence: 可通过配置直接识别低性能设备，优化低性能设备判断逻辑。

## Summary by Sourcery

New Features:
- Allow marking low-performance devices via DConfig so they can be identified directly by configuration.