### PR TITLE
fix: 将摄像头卡片过滤关键字改为 DConfig 配置

### DIFF
--- a/libcam/libcam/camview.c
+++ b/libcam/libcam/camview.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
+#include <ctype.h>
 #include <math.h>
 /* support for internationalization - i18n */
 #include <locale.h>
@@ -119,6 +120,38 @@ static char status_message[80];
 static int encode_thread_running = 0;
 
 static char project_id[200];
+
+static char **card_keywords = NULL;
+static int card_keyword_count = 0;
+
+static int is_invalid_card_keyword(const char *keyword)
+{
+    if (keyword == NULL || keyword[0] == '\0') {
+        return 1;
+    }
+
+    for (const char *p = keyword; *p != '\0'; p++) {
+        if (!isspace((unsigned char)*p)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static void clear_card_keywords(void)
+{
+    if (card_keywords == NULL) {
+        return;
+    }
+
+    for (int i = 0; i < card_keyword_count; i++) {
+        free(card_keywords[i]);
+    }
+    free(card_keywords);
+    card_keywords = NULL;
+    card_keyword_count = 0;
+}
 
 void set_video_time_capture(double video_time)
 {
@@ -1401,6 +1434,52 @@ void set_project_id(const char *id)
 const char* get_project_id(void)
 {
     return project_id;
+}
+
+void set_card_keywords(const char **keywords, int count)
+{
+    clear_card_keywords();
+
+    if (keywords == NULL || count <= 0) {
+        return;
+    }
+
+    int valid_count = 0;
+    for (int i = 0; i < count; i++) {
+        if (!is_invalid_card_keyword(keywords[i])) {
+            valid_count++;
+        }
+    }
+
+    if (valid_count == 0) {
+        return;
+    }
+
+    card_keywords = calloc((size_t)valid_count, sizeof(char *));
+    if (card_keywords == NULL) {
+        fprintf(stderr, "deepin-camera: failed to allocate card keywords\n");
+        return;
+    }
+
+    for (int i = 0; i < count; i++) {
+        if (is_invalid_card_keyword(keywords[i])) {
+            continue;
+        }
+
+        card_keywords[card_keyword_count] = strdup(keywords[i]);
+        if (card_keywords[card_keyword_count] != NULL) {
+            card_keyword_count++;
+        }
+    }
+}
+
+const char** get_card_keywords(int *count)
+{
+    if (count != NULL) {
+        *count = card_keyword_count;
+    }
+
+    return (const char **)card_keywords;
 }
 
 void set_libva_driver_name(const char *name)

--- a/libcam/libcam/camview.h
+++ b/libcam/libcam/camview.h
@@ -465,6 +465,32 @@ void set_project_id(const char *project_id);
 const char* get_project_id(void);
 
 /*
+ * set camera card keywords
+ * args:
+ *    keywords - camera card keyword string array. Each string is copied by this function;
+ *               caller retains ownership of the input array and strings.
+ *    count - keyword count
+ *
+ * asserts:
+ *    none
+ *
+ * returns: none
+ */
+void set_card_keywords(const char **keywords, int count);
+
+/*
+ * get camera card keywords
+ * args:
+ *    count - output keyword count
+ *
+ * asserts:
+ *    none
+ *
+ * returns: pointer to camera card keyword string array
+ */
+const char** get_card_keywords(int *count);
+
+/*
  * set libva driver name
  * args:
  *    name - libva driver name string

--- a/libcam/libcam_v4l2core/v4l2_devices.c
+++ b/libcam/libcam_v4l2core/v4l2_devices.c
@@ -345,6 +345,21 @@ int enum_v4l2_devices()
             continue; /*next dir entry*/
         }
         
+        int num_card_keywords = 0;
+        const char **card_keywords = get_card_keywords(&num_card_keywords);
+
+        int is_card_keyword_device = 0;
+        for (int i = 0; i < num_card_keywords; i++) {
+            if(card_keywords[i] != NULL && strstr((const char *)v4l2_cap.card, card_keywords[i]) != NULL) {
+                is_card_keyword_device = 1;
+                break;
+            }
+        }
+        if(is_card_keyword_device) {
+            getV4l2()->m_v4l2_close(fd);
+            continue; /*next dir entry*/
+        }
+
         // when project_id equals UOS2025073011543 filter out ISP devices
         const char* current_project_id = get_project_id();
         if (current_project_id != NULL && strcmp(current_project_id, UOS2025073011543) == 0) {

--- a/src/assets/org.deepin.camera.encode.json
+++ b/src/assets/org.deepin.camera.encode.json
@@ -102,6 +102,16 @@
             "permissions": "readwrite",
             "visibility": "private"
         },
+        "CardKeywords": {
+            "value": ["IR Cam", "IR Camera", "Infrared", "IR_", "-IR", "ir_cam"],
+            "serial": 0,
+            "flags": ["global"],
+            "name": "camera card keywords",
+            "name[zh_CN]": "摄像头卡片名称关键字",
+            "description": "Set camera card name keywords",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
         "preferredResolution": {
             "value": "",
             "serial": 0,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "cameraconfig.h"
 #include "acobjectlist.h"
 #include "dbus_adpator.h"
+#include "globalutils.h"
 #include <datamanager.h>
 
 #ifdef DTKCORE_CLASS_DConfigFile
@@ -29,6 +30,8 @@ extern "C" {
 
 #include <QSharedMemory>
 #include <QTime>
+#include <QByteArray>
+#include <QVector>
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -203,6 +206,23 @@ int main(int argc, char *argv[])
         QStringList deviceBlacklist = dconfig->value("deviceBlacklist").toStringList();
         qInfo() << "device blacklist:" << deviceBlacklist;
         DataManager::instance()->setDeviceBlacklist(deviceBlacklist);
+    }
+
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("CardKeywords")) {
+        QStringList cardKeywords = GlobalUtils::parseStringListConfig(dconfig->value("CardKeywords"));
+        QVector<QByteArray> keywordBytes;
+        keywordBytes.reserve(cardKeywords.size());
+        for (const QString &keyword : cardKeywords) {
+            keywordBytes.append(keyword.toUtf8());
+        }
+
+        QVector<const char *> keywordData;
+        keywordData.reserve(keywordBytes.size());
+        for (const QByteArray &keyword : keywordBytes) {
+            keywordData.append(keyword.constData());
+        }
+        qInfo() << "card keywords:" << cardKeywords;
+        set_card_keywords(keywordData.data(), keywordData.size());
     }
 
     if (dconfig && dconfig->isValid() && dconfig->keyList().contains("preferredResolution")) {

--- a/src/src/globalutils.cpp
+++ b/src/src/globalutils.cpp
@@ -87,3 +87,29 @@ void GlobalUtils::loadCameraConf()
         m_LowPerformanceBoards = QStringList();
     }
 }
+
+QStringList GlobalUtils::parseStringListConfig(const QVariant &value)
+{
+    QStringList rawList;
+
+    if (value.type() == QVariant::StringList) {
+        rawList = value.toStringList();
+    } else if (value.type() == QVariant::List) {
+        const QVariantList variantList = value.toList();
+        for (const QVariant &item : variantList) {
+            if (item.type() == QVariant::String) {
+                rawList.append(item.toString());
+            }
+        }
+    } else {
+        return QStringList();
+    }
+
+    QStringList result;
+    for (const QString &keyword : rawList) {
+        if (!keyword.trimmed().isEmpty()) {
+            result.append(keyword);
+        }
+    }
+    return result;
+}

--- a/src/src/globalutils.h
+++ b/src/src/globalutils.h
@@ -7,6 +7,8 @@
 #define GLOBALUTILS_H
 
 #include <QString>
+#include <QStringList>
+#include <QVariant>
 
 class GlobalUtils
 {
@@ -16,6 +18,8 @@ public:
 
     // 加载相机配置
     static void loadCameraConf();
+
+    static QStringList parseStringListConfig(const QVariant &value);
 
 private:
     static QStringList m_LowPerformanceBoards;


### PR DESCRIPTION
将原先在 enum_v4l2_devices 中硬编码的摄像头卡片关键字迁移到
  org.deepin.camera.encode.json 的 CardKeywords 配置项中，并在启动时
  从 DConfig 读取后动态传递给 libcam 使用，支持后续通过配置增删过滤关键字。

Log: 将摄像头卡片过滤关键字设置为DConfig配置
Bug: https://pms.uniontech.com/bug-view-363739.html

## Summary by Sourcery

Move camera card filter keywords from hardcoded v4l2 enumeration logic to a dynamic, DConfig-driven configuration and propagate them into libcam for runtime filtering.

Enhancements:
- Add libcam APIs and internal storage to set and retrieve camera card keywords at runtime.
- Load CardKeywords from org.deepin.camera.encode DConfig on startup and pass them to libcam for device filtering.
- Update v4l2 device enumeration to filter devices based on the configured card keywords instead of hardcoded strings.
- Extend the encode configuration JSON to define CardKeywords used for camera card filtering.