### PR TITLE
fix(a/v-sync): use monotonic clock for audio PTS to fix desync

### DIFF
--- a/libcam/libcam/camview.c
+++ b/libcam/libcam/camview.c
@@ -37,6 +37,7 @@
 #include <libintl.h>
 
 #include "gviewv4l2core.h"
+#include "core_time.h"
 #include "gviewrender.h"
 #include "gviewencoder.h"
 #include "gview.h"
@@ -728,6 +729,11 @@ static void *audio_processing_loop(void *data)
 
     render_set_osd_mask(osd_mask);
 
+    /* init reference to system monotonic clock on first run */
+    if (audio_timestamp_reference == 0) {
+        audio_timestamp_reference = ns_time_monotonic();
+        audio_timestamp_tmp = audio_timestamp_reference;
+    }
     while(video_capture_get_save_video())
     {
         if(get_capture_pause())
@@ -735,7 +741,7 @@ static void *audio_processing_loop(void *data)
             int ret = audio_get_next_buffer(audio_ctx, audio_buff, sample_type, my_audio_mask);
             if(ret == 0)
             {
-                audio_pause_timestamp = audio_buff->timestamp - audio_timestamp_tmp;
+                audio_pause_timestamp = ns_time_monotonic() - audio_timestamp_tmp;
             }
             continue;
         }
@@ -743,7 +749,7 @@ static void *audio_processing_loop(void *data)
         int ret = audio_get_next_buffer(audio_ctx, audio_buff,
                 sample_type, my_audio_mask);
 
-        audio_timestamp_tmp = audio_buff->timestamp;
+        audio_timestamp_tmp = ns_time_monotonic();
         if(audio_pause_timestamp != 0) {
             audio_timestamp_reference += audio_pause_timestamp;
             audio_pause_timestamp = 0;
@@ -758,7 +764,7 @@ static void *audio_processing_loop(void *data)
                 .tv_nsec = 1000000};/*nanosec*/
              nanosleep(&req, NULL);
         } else if(ret == 0) {
-            encoder_ctx->enc_audio_ctx->pts = audio_buff->timestamp - audio_timestamp_reference;
+            encoder_ctx->enc_audio_ctx->pts = ns_time_monotonic() - audio_timestamp_reference;
 
             /*OSD vu meter level*/
             render_set_vu_level(audio_buff->level_meter);

--- a/libcam/libcam_encoder/encoder.c
+++ b/libcam/libcam_encoder/encoder.c
@@ -48,6 +48,7 @@
 #include <va/va.h>
 
 #include "cameraconfig.h"
+#include "core_time.h"
 #include "gviewencoder.h"
 #include "encoder.h"
 #include "stream_io.h"
@@ -1361,7 +1362,7 @@ int encoder_flush_video_buffer(encoder_context_t *encoder_ctx)
     if (verbosity > 1)
         printf("ENCODER: flushed %i delayed video frames\n", flushed_frame_counter);
 
-    if (!buffer_count) {
+	if (!buffer_count) {
         fprintf(stderr, "ENCODER: (flush video buffer) max processed buffers reached\n");
         return -1;
     }
@@ -1941,6 +1942,7 @@ int encoder_encode_audio(encoder_context_t *encoder_ctx, void *audio_data)
                     audio_codec_data->codec_context->time_base.den);
         }
     }
+    enc_audio_ctx->original_pts = enc_audio_ctx->pts;
     ret = libav_send_encode(
               audio_codec_data->codec_context,
               audio_codec_data->frame);

--- a/libcam/libcam_encoder/gviewencoder.h
+++ b/libcam/libcam_encoder/gviewencoder.h
@@ -183,6 +183,7 @@ typedef struct _encoder_audio_context_t {
     int outbuf_coded_size;
 
     int64_t pts;
+    int64_t original_pts;    /* 纳秒时间戳，不被编码器覆盖，用于 muxer PTS 计算 */
     int64_t dts;
     int flags;
     int duration;

--- a/libcam/libcam_encoder/muxer.c
+++ b/libcam/libcam_encoder/muxer.c
@@ -218,7 +218,7 @@ int encoder_write_audio_data(encoder_context_t *encoder_ctx)
                     1,
                     enc_audio_ctx->outbuf,
             (uint32_t)enc_audio_ctx->outbuf_coded_size,
-            (uint64_t)enc_audio_ctx->pts,
+            (uint64_t)enc_audio_ctx->original_pts,
                     enc_audio_ctx->flags);
             break;
 


### PR DESCRIPTION
Audio PTS was derived from the hardware device timestamp while video PTS
  used CLOCK_MONOTONIC, causing progressive A/V drift. Unify both to
  ns_time_monotonic(). Also preserve original_pts for the muxer to avoid
  precision loss from audio codec time_base rescaling.

log: fix bug

Bug:https://pms.uniontech.com/bug-view-363537.html