### PR TITLE
fix(camera):修复摄像头被占用时仍显示倒计时的问题

### DIFF
--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -1269,7 +1269,7 @@ void CMainWindow::loadAfterShow()
         {"tid", EventLogUtils::Start},
         {"mode", 1},
         {"version", VERSION},
-        {"camera_connected", DataManager::instance()->getdevStatus() ? true : false}
+        {"camera_connected", DataManager::instance()->getdevStatus() == CAM_CANUSE}
     };
     EventLogUtils::get().writeLogs(obj);
 }
@@ -1481,21 +1481,21 @@ void CMainWindow::onPhotoRecordBtnClked()
     QJsonObject obj {
         {"tid", m_photoRecordBtn->photoState() ? EventLogUtils::StartPhoto : EventLogUtils::StartRecording},
         {"version", VERSION},
-        {"camera_connected", DataManager::instance()->getdevStatus() ? true : false}
+        {"camera_connected", DataManager::instance()->getdevStatus() == CAM_CANUSE}
     };
     if(!m_bRecording)
         EventLogUtils::get().writeLogs(obj);
 
-    //没有摄像机，不进行任何操作
-    if (NOCAM == DataManager::instance()->getdevStatus()) {
-        return;
-    }
     //拍照模式下
     if (true == m_photoRecordBtn->photoState()) {
         //正在拍照
         if (photoNormal != m_photoState) {
             m_videoPre->onTakePic(false);
         } else {
+            //摄像头不可用时，不开启新的拍照动作
+            if (CAM_CANUSE != DataManager::instance()->getdevStatus()) {
+                return;
+            }
             int nContinuous = Settings::get().getOption("photosetting.photosnumber.takephotos").toInt();
             if (nContinuous > 1) {
                 // 仅在连拍模式下才开启窗口状态监听线程
@@ -1509,6 +1509,10 @@ void CMainWindow::onPhotoRecordBtnClked()
         if (true == m_bRecording) {
             m_videoPre->onEndBtnClicked();
         } else {
+            //摄像头不可用时，不开启新的录像动作
+            if (CAM_CANUSE != DataManager::instance()->getdevStatus()) {
+                return;
+            }
             QFileInfo fi(m_videoPath);
             if (!fi.isWritable())
                 return;

--- a/src/src/titlebar.cpp
+++ b/src/src/titlebar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -62,7 +62,7 @@ void Titlebar::slotThemeTypeChanged()
 {
     Q_D(const Titlebar);
     QPalette pa;
-    if(DataManager::instance()->getdevStatus() != NOCAM) {
+    if(DataManager::instance()->getdevStatus() == CAM_CANUSE) {
         pa.setColor(QPalette::ButtonText, d->lightColor);
         d->m_titlebar->setPalette(pa);
     } else{
@@ -83,7 +83,7 @@ void Titlebar::paintEvent(QPaintEvent *pe)
     QPainter painter(this);
     QPalette pa;
 
-    if(DataManager::instance()->getdevStatus() != NOCAM) {
+    if(DataManager::instance()->getdevStatus() == CAM_CANUSE) {
         pa.setColor(QPalette::ButtonText, d->lightColor);
         d->m_titlebar->setPalette(pa);
     }


### PR DESCRIPTION
Log: 修复摄像头被占用时仍显示倒计时的问题
Bug: https://pms.uniontech.com/bug-view-364831.html
Influence: 摄像头被其它应用占用时，点击拍照或录像不再显示0或负数倒计时；日志中的camera_connected仅在摄
像头可用时记录为true。

## Summary by Sourcery

Prevent starting photo capture or video recording when the camera is unavailable or occupied, and refine camera availability logging.

Bug Fixes:
- Stop initiating new photo actions when the camera is not in a usable state.
- Stop initiating new video recording actions when the camera is not in a usable state.
- Ensure camera_connected is logged as true only when the camera is actually usable.