### PR TITLE
chore: Update version to 6.5.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-camera (6.5.41) unstable; urgency=medium
+
+  * chore: Update version to 6.5.41
+  * [skip CI] Translate deepin-camera_en_US.ts in cs
+  * fix: Use D-Bus session query to get DistroID for file prefix
+  * fix: 异步调用 DBus 打开缩略图文件
+  * fix(tests): migrate unit tests to Qt6 and fix DEADLYSIGNAL crash
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Wed, 17 Jun 2026 15:20:23 +0800
+
 deepin-camera (6.5.40) unstable; urgency=medium
 
   * [skip CI] Translate deepin-camera_en_US.ts in ru

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.40.1
+  version: 6.5.41.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
- update version to 6.5.41

log: update version to 6.5.41

## Summary by Sourcery

Build:
- Update linglong package manifest to version 6.5.41.1.