### PR TITLE
chore: add .gitignore for C++ and Qt artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# C++ objects and libs
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.so.*
+*.dll
+*.dylib
+
+# Qt-es
+object_script.*.Release
+object_script.*.Debug
+*_plugin_import.cpp
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
+ui_*.h
+*.qmlc
+*.jsc
+Makefile*
+*build-*
+build/
+*.qm
+*.prl
+*.qmlls.ini
+
+# Qt unit tests
+target_wrapper.*
+
+# QtCreator
+*.autosave
+
+# QtCreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCreator CMake
+CMakeLists.txt.user*
+
+# QtCreator 4.8< compilation database
+compile_commands.json
+
+# QtCreator local machine specific files for imported projects
+*creator.user*
+
+*_qmlcache.qrc


### PR DESCRIPTION
Added a .gitignore file to exclude common C++ object files, Qt build artifacts, and QtCreator-specific configurations. This prevents generated files and local IDE settings from being accidentally committed to the repository.

## Summary by Sourcery

Build:
- Add .gitignore entries to exclude common C++ object files, Qt build artifacts, and QtCreator-specific configuration files from version control.