### PR TITLE
fix(videowidget): fix hi-dpi display scaling in video widget

### DIFF
--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -581,17 +581,24 @@ void videowidget::ReceiveMajorImage(QImage *image, int result)
             if (m_openglwidget && m_openglwidget->isVisible())
                 m_openglwidget->hide();
             {
-                int widgetwidth = this->width();
-                int widgetheight = this->height();
-                if ((image->width() * 100 / image->height()) > (widgetwidth * 100 / widgetheight)) {
-                    QImage img = image->scaled(widgetwidth, widgetwidth * image->height() / image->width(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-                    m_framePixmap = QPixmap::fromImage(img);
+                const qreal dpr = this->devicePixelRatioF();
+                const int widgetwidth = qRound(this->width() * dpr);
+                const int widgetheight = qRound(this->height() * dpr);
+
+                int targetWidth, targetHeight;
+                if (qint64(image->width()) * widgetheight > qint64(widgetwidth) * image->height()) {
+                    targetWidth = widgetwidth;
+                    targetHeight = qMin(qRound(qreal(widgetwidth) * image->height() / image->width()), widgetheight);
                 } else {
-                    QImage img = image->scaled(widgetheight * image->width() / image->height(), widgetheight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-                    m_framePixmap = QPixmap::fromImage(img);
+                    targetHeight = widgetheight;
+                    targetWidth = qMin(qRound(qreal(widgetheight) * image->width() / image->height()), widgetwidth);
                 }
 
-                m_pNormalScene->setSceneRect(m_framePixmap.rect());
+                m_framePixmap = QPixmap::fromImage(image->scaled(targetWidth, targetHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+                m_framePixmap.setDevicePixelRatio(dpr);
+
+                const QRectF sceneRect(0, 0, qreal(m_framePixmap.width()) / dpr, qreal(m_framePixmap.height()) / dpr);
+                m_pNormalScene->setSceneRect(sceneRect);
                 m_pNormalItem->setPixmap(m_framePixmap);
 
                 if (DataManager::instance()->encodeEnv() == FFmpeg_Env) {


### PR DESCRIPTION
Use devicePixelRatioF() for proper HiDPI scaling, prevent integer overflow in aspect ratio comparison, and fix scene rect calculation with logical coordinates.

修复视频预览控件在高DPI屏幕下的显示缩放问题，使用 devicePixelRatioF() 处理像素比例，防止整数溢出，并修复场景矩形计算。

Log: 修复 videowidget 高DPI显示缩放问题
PMS: BUG-369935
Influence: 修复后视频预览在高DPI屏幕上正常显示，画面比例和场景矩形坐标正确。

## Summary by Sourcery

Fix HiDPI video preview scaling and scene rectangle calculation in the video widget.

Bug Fixes:
- Correct video preview scaling on high-DPI displays by using device pixel ratio in widget size and pixmap handling.
- Prevent integer overflow when comparing aspect ratios between the video image and the widget.

Enhancements:
- Adjust scene rectangle to use logical coordinates based on device pixel ratio so the displayed frame size matches the widget accurately.