### PR TITLE
fix(logging): add Qt logging filter rules initialization

### DIFF
--- a/src/assets/org.deepin.camera.encode.json
+++ b/src/assets/org.deepin.camera.encode.json
@@ -2,6 +2,19 @@
     "magic": "dsg.config.meta",
     "version": "1.0",
     "contents": {
+        "rules": {
+            "value": "*.debug=false;*.info=false;*.warning=true",
+            "serial": 0,
+            "flags": [
+                "global"
+            ],
+            "name": "rules",
+            "name[zh_CN]": "日志规则",
+            "description": "log rules",
+            "description[zh_CN]": "日志规则",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "mp4EncodeMode": {
             "value": -1,
             "serial": 0,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,8 +32,12 @@ extern "C" {
 #include <DApplicationSettings>
 #endif
 
+#include "ddlog.h"
+#include "logconfigread.h"
+
 #include <QSharedMemory>
 #include <QTime>
+#include <QLoggingCategory>
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -135,6 +139,9 @@ static void handleSignal(int sig)
 
 int main(int argc, char *argv[])
 {
+    // 初始化日志规则：读取环境变量和 DConfig 配置
+    MLogger logger;
+
     qInfo() << "Starting deepin-camera application...";
     // Task 326583 不参与合成器崩溃重连
     unsetenv("QT_WAYLAND_RECONNECT");

--- a/src/src/ddlog.h
+++ b/src/src/ddlog.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DDLOG_H
+#define DDLOG_H
+
+#include <DLog>
+#include <dtkcore_global.h>
+
+DCORE_USE_NAMESPACE
+
+namespace DDLog {
+inline Q_LOGGING_CATEGORY(appLog, "org.deepin.camera")
+}
+
+#endif // DDLOG_H

--- a/src/src/logconfigread.cpp
+++ b/src/src/logconfigread.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "logconfigread.h"
+#include "ddlog.h"
+#include "dtkcore_global.h"
+#include "qglobal.h"
+#include <QLoggingCategory>
+#include <QObject>
+#include <DConfig>
+
+DCORE_USE_NAMESPACE
+using namespace DDLog;
+
+MLogger::MLogger(QObject *parent)
+    : QObject(parent), m_rules(""), m_config(nullptr) {
+    QByteArray logRules = qgetenv("QT_LOGGING_RULES");
+    // qunsetenv 之前一定不要有任何日志打印，否则取消环境变量设置不会生效
+    qunsetenv("QT_LOGGING_RULES");
+    // 保存环境变量中的规则
+    m_rules = logRules;
+    // 从 DConfig 读取日志规则
+    m_config = DConfig::create("org.deepin.camera", "org.deepin.camera.encode");
+    if (m_config && m_config->isValid()) {
+        logRules = m_config->value("rules").toByteArray();
+        appendRules(logRules);
+        setRules(m_rules);
+        // 监听 DConfig 变化，动态更新日志规则
+        connect(m_config, &DConfig::valueChanged, this, [this](const QString &key) {
+            if (key == "rules") {
+                setRules(m_config->value(key).toByteArray());
+            }
+        });
+    }
+}
+
+MLogger::~MLogger() {
+    if (m_config) {
+        m_config->deleteLater();
+    }
+}
+
+void MLogger::setRules(const QString &rules) {
+    auto tmpRules = rules;
+    m_rules = tmpRules.replace(";", "\n");
+    QLoggingCategory::setFilterRules(m_rules);
+}
+
+void MLogger::appendRules(const QString &rules) {
+    QString tmpRules = rules;
+    tmpRules = tmpRules.replace(";", "\n");
+    auto tmplist = tmpRules.split('\n');
+    for (int i = 0; i < tmplist.count(); i++) {
+        if (m_rules.contains(tmplist.at(i))) {
+            tmplist.removeAt(i);
+            i--;
+        }
+    }
+    if (tmplist.isEmpty()) {
+        return;
+    }
+    m_rules.isEmpty() ? m_rules = tmplist.join("\n")
+                      : m_rules += "\n" + tmplist.join("\n");
+}

--- a/src/src/logconfigread.h
+++ b/src/src/logconfigread.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef LOGCONFIGREAD_H
+#define LOGCONFIGREAD_H
+
+#include <QObject>
+#include <dtkcore_global.h>
+
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
+
+class MLogger : public QObject {
+    Q_OBJECT
+public:
+    explicit MLogger(QObject *parent = nullptr);
+    ~MLogger();
+
+    inline QString rules() const { return m_rules; }
+    void setRules(const QString &rules);
+
+private:
+    void appendRules(const QString &rules);
+
+private:
+    QString m_rules;
+    Dtk::Core::DConfig *m_config;
+};
+
+#endif // LOGCONFIGREAD_H


### PR DESCRIPTION
Add initLoggingRules() to read QT_LOGGING_RULES environment variable for log filtering. Default to disabling debug logs when unset.

添加 Qt 日志过滤规则初始化，通过 QT_LOGGING_RULES 环境变量控制日志输出，
未设置时默认关闭 debug 日志。

Log: 添加 Qt 日志过滤规则初始化功能
PMS: BUG-369935
Influence: 应用启动时可通过环境变量控制日志级别，默认关闭 debug 日志减少输出噪音。

## Summary by Sourcery

Enhancements:
- Add centralized initialization of Qt logging filter rules using QT_LOGGING_RULES, with a default rule that disables debug-level logging.