### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/deepin-camera.desktop
+++ b/src/deepin-camera.desktop
@@ -110,7 +110,7 @@ Name[sr]=Дипин Камера
 Name[tr]=Deepin Kamera
 Name[ug]=Deepinكامىرا 
 Name[uk]=Камера Deepin
-Name[zh_CN]=深度相机
-Name[zh_HK]=Deepin 相機
-Name[zh_TW]=Deepin 相機
+Name[zh_CN]=相机
+Name[zh_HK]=相機
+Name[zh_TW]=相機
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Ensure zh_CN/zh_HK/zh_TW desktop entry names and comments no longer include the "深度"/"deepin"/"Deepin" brand prefix, aligning translations with expected app naming.