### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/deepin-camera.desktop
+++ b/src/deepin-camera.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Type=Application
 X-Deepin-TurboType=dtkwidget
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 X-MultipleArgs=false
 
 # Translations:


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

New Features:
- Introduce singleton metadata flag in the deepin-camera desktop entry to integrate with AM and Treeland behavior.