### PR TITLE
fix(exposureslider): always set focus after slider animation

### DIFF
--- a/src/src/exposureslider.cpp
+++ b/src/src/exposureslider.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -118,10 +118,7 @@ void ExposureSlider::showContent(bool show, bool isShortCut)
 
         connect(pGroup, &QParallelAnimationGroup::finished, this, [=](){
             qDebug() << "Animation finished, handling cleanup";
-            if (isShortCut) { //键盘触发，需在此处理焦点
-                qDebug() << "Setting focus to slider after shortcut activation";
-                m_slider->slider()->setFocus();
-            }
+            m_slider->slider()->setFocus();
             pGroup->deleteLater();
         });
 


### PR DESCRIPTION
Remove the isShortCut condition check so the exposure slider always gains keyboard focus after fade-in animation completes.

移除isShortCut条件判断，使曝光滑块在淡入动画结束后
始终获得键盘焦点。

Log: 修复曝光滑块动画结束后无法获得焦点的问题
PMS: BUG-350117
Influence: 修复后曝光滑块在所有触发方式下均可正确获取焦点，用户可通过方向键调整曝光值。

## Summary by Sourcery

Ensure the exposure slider always receives keyboard focus after its fade-in animation completes, regardless of how it was triggered.

Bug Fixes:
- Fix missing keyboard focus on the exposure slider after animation when triggered by non-shortcut interactions.

Enhancements:
- Update copyright and SPDX metadata years for the exposure slider implementation.