### PR TITLE
feat(config): add useRgbData config to control RGB preview mode

### DIFF
--- a/src/assets/org.deepin.camera.encode.json
+++ b/src/assets/org.deepin.camera.encode.json
@@ -134,6 +134,16 @@
             "description": "Is low performance device",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "useRgbData": {
+            "value": -1,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "use RGB data for preview",
+            "name[zh_CN]": "是否使用RGB数据进行预览显示，-1表示不设置，由系统自动判断；0表示强制关闭；1表示强制开启",
+            "description": "Force use RGB data for preview rendering. -1: not set (auto), 0: force disable, 1: force enable. When enabled, YUV frames will be converted to RGB format before display.",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,6 +250,16 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("useRgbData")) {
+        int useRgbData = dconfig->value("useRgbData").toInt();
+        if (useRgbData != -1 && useRgbData != 0 && useRgbData != 1) {
+            qWarning() << "Invalid useRgbData value in config:" << useRgbData << "- mapping to default value -1 (auto)";
+            useRgbData = -1; 
+        }
+        qInfo() << "use RGB data for preview:" << useRgbData;
+        DataManager::instance()->setUseRgbData(useRgbData);
+    }
+
     if (!libVaDriverName.isEmpty()) {
         qputenv("LIBVA_DRIVER_NAME", libVaDriverName.toLocal8Bit());
     }

--- a/src/src/basepub/datamanager.h
+++ b/src/src/basepub/datamanager.h
@@ -211,6 +211,18 @@ public:
      * @return 分辨率
      */
     QSize getPreferredResolution();
+
+    /**
+     * @brief 设置RGB数据预览模式
+     * @param mode -1:不设置(自动), 0:强制关闭, 1:强制开启
+     */
+    void setUseRgbData(int mode) { m_useRgbData = mode; };
+
+    /**
+     * @brief 获取RGB数据预览模式
+     * @return -1:不设置(自动), 0:强制关闭, 1:强制开启
+     */
+    int getUseRgbData() const { return m_useRgbData; };
 private:
     DataManager();
     static DataManager *m_dataManager;
@@ -226,5 +238,6 @@ private:
     bool m_enable8kPreview = false; // 是否启用8K预览
     QSet<QString> m_deviceBlacklistSet; // 设备黑名单
     QSize m_preferredResolution; // 首选分辨率
+    int m_useRgbData = -1; // RGB数据预览模式：-1不设置(自动), 0强制关闭, 1强制开启
 };
 #endif // DATAMANAGER_H

--- a/src/src/majorimageprocessingthread.cpp
+++ b/src/src/majorimageprocessingthread.cpp
@@ -305,6 +305,14 @@ void MajorImageProcessingThread::run()
             if (GStreamer_Env == m_eEncodeEnv)
                 bUseRgb = true;
 
+            // DConfig配置控制RGB数据使用模式，-1表示不设置(由系统自动判断)，0表示强制关闭，1表示强制开启
+            int useRgbData = DataManager::instance()->getUseRgbData();
+            if (useRgbData == 1) {
+                bUseRgb = true;
+            } else if (useRgbData == 0) {
+                bUseRgb = false;
+            }
+
             if (bUseRgb || (m_bPhoto && m_filtersGroupDislay)) {
                 // qDebug() << "Processing video frame in rgb mode";
                 if (m_nVdWidth != static_cast<unsigned int>(m_frame->width) || m_nVdHeight != static_cast<unsigned int>(m_frame->height)) {


### PR DESCRIPTION
Add DConfig option "useRgbData" to control whether YUV frames are converted to RGB for preview rendering. Supports three modes: -1: auto (default, let system decide)
0: force disable
1: force enable

添加DConfig配置项"useRgbData"，控制预览时是否将YUV帧数据转换为RGB格式。
支持三态：-1自动判断（默认）、0强制关闭、1强制开启。

Log: 添加RGB预览模式配置项
PMS: BUG-366739
Influence: 通过DConfig配置可强制控制预览RGB数据的使用，便于排查特定机型显示异常问题。