### PR TITLE
fix(camera): prefer DConfig resolution over local config (BUG-366203)

### DIFF
--- a/src/src/LPF_V4L2.c
+++ b/src/src/LPF_V4L2.c
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,7 @@ extern "C" {
 #include "audio.h"
 #include "core_io.h"
 #include "colorspaces.h"
+#include "v4l2_formats.h"
 
 int camInit(const char *devicename)
 {
@@ -210,12 +211,15 @@ int camInit(const char *devicename)
         v4l2core_prepare_new_format(my_vd, (int)my_config->format);
 
         if ((strcmp(my_config->device_name, devlist->list_devices[my_vd->this_device].name) == 0) && (strcmp(my_config->device_location, my_vd->videodevice) == 0)) {
-            v4l2core_prepare_new_resolution(my_vd, my_config->width, my_config->height);
-            // 分辨率可能已经被校正
-            if (my_config->width != get_my_width() || my_config->height != get_my_height()) {
-                printf("%s: adjust resolution(%dx%d => %dx%d)\n", __func__, my_config->width, my_config->height, get_my_width(), get_my_height());
+            // DConfig preferredResolution 优先于本地配置文件中的分辨率
+            if (get_preferred_resolution_width() > 0 && get_preferred_resolution_height() > 0) {
+                v4l2core_prepare_new_resolution(my_vd,
+                    get_preferred_resolution_width(),
+                    get_preferred_resolution_height());
                 my_config->width  = get_my_width();
                 my_config->height = get_my_height();
+            } else {
+                v4l2core_prepare_new_resolution(my_vd, my_config->width, my_config->height);
             }
             ret = v4l2core_update_old_format(my_vd, my_config->width, my_config->height, v4l2core_get_requested_frame_format(my_vd));
         } else {


### PR DESCRIPTION
When preferredResolution is set via DConfig, use it directly instead of the locally cached resolution from config file on first launch.

DConfig的preferredResolution配置优先于本地配置文件中的分辨率，
修复首次打开应用时仍使用本地旧配置的问题。

Log: 修复preferredResolution首次启动不生效的问题
PMS: BUG-366203
Influence: 设置preferredResolution后首次启动即可生效，无需重启两次。