### PR TITLE
fix(settings): use combo box for photo format

### DIFF
--- a/src/assets/resource/settings.json
+++ b/src/assets/resource/settings.json
@@ -165,8 +165,11 @@
                         {
                             "key": "picformat",
                             "name": "Photo:",
-                            "type":"formatLabel",
-                            "default": "  JPG"
+                            "type":"combobox",
+                            "items": [
+                                "JPG"
+                            ],
+                            "default": 0
                         },
                         {
                             "key": "vidformat",

--- a/src/src/accessibility/ac-deepin-camera-define.h
+++ b/src/src/accessibility/ac-deepin-camera-define.h
@@ -15,7 +15,6 @@
 
 #define BUTTON_OPTION_PIC_LINE_EDIT QObject::tr("OptionPicLineEditBtn")
 #define BUTTON_OPTION_VIDEO_LINE_EDIT QObject::tr("OptionVideoLineEditBtn")
-#define OPTION_FORMAT_LABER QObject::tr("OptionFormatLabel")
 #define OPTION_FRAME QObject::tr("OptionFrame")
 #define PIC_OPTION QObject::tr("PicOption")
 #define VIDEO_OPTION QObject::tr("VideoOption")

--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -131,48 +131,6 @@ static QString ElideText(const QString &text, const QSize &size,
     return textlinestr;
 }
 
-static QWidget *createFormatLabelOptionHandle(QObject *opt)
-{
-    DTK_CORE_NAMESPACE::DSettingsOption *option = qobject_cast<DTK_CORE_NAMESPACE::DSettingsOption *>(opt);
-    DLabel *lab = new DLabel();
-    DWidget *main = new DWidget();
-    QHBoxLayout *layout = new QHBoxLayout;
-    QWidget *optionWidget = new QWidget;
-    QFormLayout *optionLayout = new QFormLayout(optionWidget);
-
-    main->setLayout(layout);
-    main->setContentsMargins(0, 0, 0, 0);
-    main->setMinimumWidth(240);
-    main->setMinimumHeight(20);
-    layout->addWidget(lab);
-    layout->setContentsMargins(0, 0, 0, 0);
-    layout->setAlignment(Qt::AlignVCenter);
-    lab->setObjectName(OPTION_FORMAT_LABER);
-    lab->setAccessibleName(OPTION_FORMAT_LABER);
-    lab->setMinimumHeight(20);
-
-    lab->setText(option->value().toString());
-    QFont ft("SourceHanSansSC");
-    ft.setPixelSize(15);
-    ft.setWeight(QFont::Medium);
-    lab->setFont(ft);
-    lab->setAlignment(Qt::AlignVCenter);
-    lab->show();
-    optionWidget->setObjectName(OPTION_FRAME);
-    optionWidget->setAccessibleName(OPTION_FRAME);
-    optionLayout->setContentsMargins(0, 0, 0, 0);
-
-    optionLayout->setSpacing(0);
-    DLabel *dLabel = new DLabel(QObject::tr(option->name().toStdString().c_str()));
-    dLabel->setMinimumHeight(20);
-    dLabel->setAlignment(Qt::AlignVCenter);
-    optionLayout->addRow(dLabel, main);
-    optionWidget->setContentsMargins(0, 0, 0, 0);
-    workaround_updateStyle(optionWidget, "light");
-
-    return optionWidget;
-}
-
 static QWidget *createPicSelectableLineEditOptionHandle(QObject *opt)
 {
     DTK_CORE_NAMESPACE::DSettingsOption *option = qobject_cast<DTK_CORE_NAMESPACE::DSettingsOption *>(opt);
@@ -1077,7 +1035,6 @@ void CMainWindow::settingDialog()
     m_SetDialog->setFixedSize(820, 600);
     m_SetDialog->widgetFactory()->registerWidget("selectableEditpic", createPicSelectableLineEditOptionHandle);
     m_SetDialog->widgetFactory()->registerWidget("selectableEditvd", createVdSelectableLineEditOptionHandle);
-    m_SetDialog->widgetFactory()->registerWidget("formatLabel", createFormatLabelOptionHandle);
     m_SetDialog->setObjectName(SETTING_DIALOG);
     m_SetDialog->setAccessibleName(SETTING_DIALOG);
 


### PR DESCRIPTION
Replace the read-only photo format label with the standard settings combo box.

The photo output format now exposes a single JPG option, keeping the control consistent with other output settings and allowing future formats to be added without another UI rewrite.

Remove the obsolete formatLabel widget registration, implementation, and accessibility identifier.

Validation: JSON syntax check, static reference check, and git diff --check.

Related: BUG-156865

## Summary by Sourcery

Replace the photo format settings label with a standard combo box control and remove the obsolete label widget wiring.

New Features:
- Expose the photo output format as a selectable settings combo box, initially offering a single JPG option.

Enhancements:
- Remove the custom format label widget implementation and its registration from the settings dialog.
- Drop the unused accessibility identifier for the photo format label from the accessibility definitions.