### PR TITLE
chore: Update version to 6.5.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+deepin-camera (6.5.44) unstable; urgency=medium
+
+  * chore: Update version to 6.5.44
+  * fix(camera): prefer DConfig resolution over local config (BUG-366203)
+  * feat(config): add useRgbData config to control RGB preview mode
+  * fix(config): support low performance device config
+  * feat: enable the configuration for the preferred resolution.
+  * feat: enable the configuration for device blacklist.
+  * feat: enable the configuration for 8K preview.
+  * feat: Add the logic for switching cameras by USB groups.
+  * fix: Update cppcheck workflow to use checkout@v7
+  * fix(exposureslider): always set focus after slider animation
+  * fix: add X-Deepin-Singleton flag to desktop file
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:07:01 +0800
+
 deepin-camera (6.5.43) unstable; urgency=medium
 
   * chore: Update version to 6.5.43

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.43.1
+  version: 6.5.44.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
- update version to 6.5.44

log: update version to 6.5.44

## Summary by Sourcery

Bump application package version metadata to 6.5.44.1 in linglong configuration.