### PR TITLE
fix(camera): warm up shutter audio on demand

### DIFF
--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -84,7 +84,14 @@ videowidget::videowidget(DWidget *parent)
     m_pNormalItem->setZValue(0);
 
     m_bActive = false;   //是否录制中
-    m_takePicSound = new QSound(":/resource/Camera.wav");
+    m_takePicSound = new QSoundEffect(this);
+    m_takePicSound->setSource(QUrl("qrc:/resource/Camera.wav"));
+    m_takePicSound->setLoopCount(1);
+    m_takePicSound->setVolume(1.0);
+    connect(m_takePicSound, &QSoundEffect::playingChanged,
+            this, &videowidget::onShutterSoundPlayingChanged);
+    connect(m_takePicSound, &QSoundEffect::statusChanged,
+            this, &videowidget::onShutterSoundStatusChanged);
     m_countTimer = new QTimer(this);
     m_flashTimer = new QTimer(this);
     m_recordingTimer = new QTimer(this);
@@ -908,11 +915,60 @@ void videowidget::showRecTime()
     m_recordingTime->setText(strTime);
 }
 
+void videowidget::startShutterSoundWarmup()
+{
+    if (m_shutterSoundWarming || m_takePicSound->status() != QSoundEffect::Ready) {
+        return;
+    }
+
+    m_shutterSoundWarming = true;
+    m_takePicSound->setVolume(0.0);
+    m_takePicSound->play();
+}
+
+void videowidget::onShutterSoundPlayingChanged()
+{
+    if (!m_shutterSoundWarming) {
+        return;
+    }
+
+    if (m_takePicSound->isPlaying()) {
+        m_takePicSound->stop();
+        return;
+    }
+
+    m_shutterSoundWarming = false;
+    m_takePicSound->setVolume(1.0);
+    if (m_shutterSoundPending && get_sound_of_takeing_photo()) {
+        m_shutterSoundPending = false;
+        QTimer::singleShot(0, this, [this] {
+            if (get_sound_of_takeing_photo()) {
+                m_takePicSound->play();
+            }
+        });
+        return;
+    }
+    m_shutterSoundPending = false;
+}
+
+void videowidget::onShutterSoundStatusChanged()
+{
+    if (m_takePicSound->status() == QSoundEffect::Error) {
+        m_shutterSoundWarming = false;
+        m_shutterSoundPending = false;
+        m_takePicSound->setVolume(1.0);
+    } else if (m_shutterSoundPending) {
+        startShutterSoundWarmup();
+    }
+}
+
 void videowidget::flash()
 {
     qDebug() << __func__;
-    if (get_sound_of_takeing_photo())
-        m_takePicSound->play();
+    if (get_sound_of_takeing_photo()) {
+        m_shutterSoundPending = true;
+        startShutterSoundWarmup();
+    }
 
 #ifndef __mips__
     if (!get_wayland_status()) {
@@ -1845,6 +1901,7 @@ videowidget::~videowidget()
     delete m_flashLabel;
     m_flashLabel = nullptr;
 
+    m_takePicSound->stop();
     delete m_takePicSound;
     m_takePicSound = nullptr;
 
@@ -1853,9 +1910,6 @@ videowidget::~videowidget()
 
     delete m_pNormalScene;
     m_pNormalScene = nullptr;
-
-    delete m_takePicSound;
-    m_takePicSound = nullptr;
 
     delete m_pGridLayout;
     m_pGridLayout = nullptr;

--- a/src/src/videowidget.h
+++ b/src/src/videowidget.h
@@ -17,7 +17,7 @@
 #include <QOpenGLWidget>
 #include <QOpenGLFunctions>
 #include <QOpenGLBuffer>
-#include <QtMultimedia/QSound>
+#include <QtMultimedia/QSoundEffect>
 #include <QDateTime>
 #include <QSvgRenderer>
 #include <QGraphicsView>
@@ -388,16 +388,20 @@ private slots:
     * @brief onReachMaxDelayedFrames　达到视频帧最大延迟
     */
     void onReachMaxDelayedFrames();
-
     /**
     * @brief flash　闪光
     */
     void flash();
 
+    void startShutterSoundWarmup();
+    void onShutterSoundPlayingChanged();
+    void onShutterSoundStatusChanged();
+
     /**
     * @brief slotresolutionchanged　分辨率改变槽函数
     * @param 分辨率字符串(如：1920*1080)
     */
+
     void slotresolutionchanged(const QString &);
 
     /**
@@ -529,7 +533,9 @@ private:
     DLabel                     *m_recordingTime;    //录制时长
     QString                    m_videoFormat;       //录制视频格式
 
-    QSound                     *m_takePicSound;     //拍照声音
+    QSoundEffect               *m_takePicSound;     //拍照声音
+    bool                        m_shutterSoundWarming = false;
+    bool                        m_shutterSoundPending = false;
     QString                    m_savePicFolder;     //图片文件夹路径
     QString                    m_saveVdFolder;      //视频文件夹路径
     QTimer                     *m_countTimer;       //倒计时定时器


### PR DESCRIPTION
## Summary
- Replace Qt 5 QSound shutter playback with QSoundEffect.
- Silently warm the audio stream before each shutter sound.
- Stop the warmup stream before the real shutter playback to avoid continuous audio power usage.

## Verification
- cmake --build obj-x86_64-linux-gnu --target deepin-camera -- -j2

PMS: https://pms.uniontech.com/bug-view-369937.html

## Summary by Sourcery

Replace the photo shutter sound implementation with a warmed-up QSoundEffect-based playback to reduce latency while avoiding continuous audio power usage.

New Features:
- Introduce on-demand shutter sound warmup before photo capture using QSoundEffect.

Bug Fixes:
- Prevent shutter sound latency and unintended continuous audio power usage by warming and stopping the audio stream before actual playback.

Enhancements:
- Refine shutter sound lifecycle handling in videowidget, including status/playing change reactions and proper cleanup in the destructor.