### PR TITLE
chore: Update version to 6.5.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-camera (6.5.45) unstable; urgency=medium
+
+  * chore: Update version to 6.5.45
+  * fix(camera): fix OpenGL preview rendering and frame ownership (BUG-372435)
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 06 Aug 2026 19:22:06 +0800
+
 deepin-camera (6.5.44) unstable; urgency=medium
 
   * chore: Update version to 6.5.44

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.44.1
+  version: 6.5.45.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
- update version to 6.5.45

log: update version to 6.5.45

## Summary by Sourcery

Chores:
- Update linglong package manifest to version 6.5.45.1.