### PR TITLE
fix: use SIGNAL/SLOT macro for sigYUVFrame connect

### DIFF
--- a/src/src/videowidget.cpp
+++ b/src/src/videowidget.cpp
@@ -298,8 +298,8 @@ void videowidget::delayInit()
         connect(m_imgPrcThread, SIGNAL(SendMajorImageProcessing(QImage *, int)),
                 this, SLOT(ReceiveMajorImage(QImage *, int)));
         connect(m_imgPrcThread, SIGNAL(sigRenderYuv(bool)), this, SLOT(ReceiveOpenGLstatus(bool)));
-        connect(m_imgPrcThread, &MajorImageProcessingThread::sigYUVFrame,
-                m_openglwidget, &PreviewOpenglWidget::slotShowYuv,
+        connect(m_imgPrcThread, SIGNAL(sigYUVFrame(std::shared_ptr<uchar[]>,uint,uint)),
+                m_openglwidget, SLOT(slotShowYuv(std::shared_ptr<uchar[]>,uint,uint)),
                 Qt::DirectConnection);
     }
 


### PR DESCRIPTION
Replace new-style connect with old-style SIGNAL/SLOT macro syntax for sigYUVFrame signal connection to ensure compatibility.

将sigYUVFrame信号连接从新式函数指针语法改为旧式SIGNAL/SLOT宏语法以确保兼容性。

Log: 修改sigYUVFrame连接方式为SIGNAL/SLOT宏语法
PMS: BUG-372435
Influence: 仅影响YUV帧信号连接方式，功能行为不变。

## Summary by Sourcery

Bug Fixes:
- Resolve a compatibility issue by replacing the new-style function pointer connect for sigYUVFrame with the old-style SIGNAL/SLOT macro syntax.