### PR TITLE
chore: Update version to 6.5.46

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-camera (6.5.46) unstable; urgency=medium
+
+  * chore: Update version to 6.5.46
+  * fix: use SIGNAL/SLOT macro for sigYUVFrame connect
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 07 Aug 2026 09:02:04 +0800
+
 deepin-camera (6.5.45) unstable; urgency=medium
 
   * chore: Update version to 6.5.45

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.45.1
+  version: 6.5.46.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
- update version to 6.5.46

log: update version to 6.5.46

## Summary by Sourcery

Bump the deepin-camera package version metadata to 6.5.46.1.