### PR TITLE
fix(camera): use combobox for photo output format

### DIFF
--- a/src/assets/resource/panel_settings.json
+++ b/src/assets/resource/panel_settings.json
@@ -167,8 +167,8 @@
                         {
                             "key": "picformat",
                             "name": "Photo:",
-                            "type":"formatLabel",
-                            "default": "  JPG"
+                            "type":"combobox",
+                            "default": 0
                         },
                         {
                             "key": "vidformat",

--- a/src/assets/resource/settings.json
+++ b/src/assets/resource/settings.json
@@ -165,8 +165,8 @@
                         {
                             "key": "picformat",
                             "name": "Photo:",
-                            "type":"formatLabel",
-                            "default": "  JPG"
+                            "type":"combobox",
+                            "default": 0
                         },
                         {
                             "key": "vidformat",

--- a/src/src/Settings.cpp
+++ b/src/src/Settings.cpp
@@ -70,6 +70,10 @@ void Settings::init()
     }
     m_settings->option("outsetting.outformat.vidformat")->setData("items", videoFormatList);
 
+    QStringList photoFormatList;
+    photoFormatList << tr("JPG") << tr("PNG");
+    m_settings->option("outsetting.outformat.picformat")->setData("items", photoFormatList);
+
     m_settings->setBackend(m_backend);
 
     connect(m_settings, &DSettings::valueChanged, this, &Settings::onValueChanged);
@@ -267,6 +271,14 @@ void Settings::onValueChanged(const QString & key, const QVariant & value)
         if (value >= 0 && formatOpt->data("items").toStringList().size() > value.toInt()) {
             QString videoFormat = formatOpt->data("items").toStringList()[value.toInt()];
             emit videoFormatChanged(videoFormat);
+        }
+    }
+
+    if (key.startsWith("outsetting.outformat.picformat")) {
+        QPointer<DSettingsOption> formatOpt = m_settings->option("outsetting.outformat.picformat");
+        if (value >= 0 && formatOpt->data("items").toStringList().size() > value.toInt()) {
+            QString photoFormat = formatOpt->data("items").toStringList()[value.toInt()];
+            emit photoFormatChanged(photoFormat);
         }
     }
 }

--- a/src/src/Settings.h
+++ b/src/src/Settings.h
@@ -154,6 +154,12 @@ signals:
      */
     void videoFormatChanged(QString format);
 
+    /**
+     * @brief photoFormatChanged 拍照照片格式
+     * @param format 照片格式
+     */
+    void photoFormatChanged(QString format);
+
 private:
     Settings();
     static Settings     m_instance;


### PR DESCRIPTION
# fix(camera): 照片输出格式改为下拉框

> PMS: https://pms.uniontech.com/bug-view-156865.html
> 基线（base）: `5a8a1a95a3cde2db35a48658f53a566fc97430e1`（release/eagle）

## 根因分析

设置界面"输出格式-照片"显示为静态文本而非下拉框。根因：`src/assets/resource/settings.json` 中 `outsetting.outformat.picformat` 的控件类型声明为自定义 `formatLabel`，对应工厂 `createFormatLabelOptionHandle`（`src/src/mainwindow.cpp`）只渲染只读 `DLabel`（"  JPG"）；而同组 `vidformat` 已是 `combobox`。两者类型不一致导致照片格式不是下拉框。

关键证据：
- `settings.json:166-170` / `panel_settings.json:164-168`：`picformat` type=`formatLabel`，`vidformat` type=`combobox`。
- `mainwindow.cpp:134`：`createFormatLabelOptionHandle` 渲染静态 `DLabel`，无下拉交互。

（问题点 1、2：分割线/行高/间距根因在 DTK5 `dtkwidget` 上游 `content.cpp` 硬编码，不在本仓库，经根因复核不在本次范围。）

## 修复方案

仿照同组已正常工作的 `vidformat`（combobox + items + onValueChanged emit `videoFormatChanged`）镜像实现 `picformat`：

1. `settings.json` / `panel_settings.json`：`picformat` type `formatLabel`→`combobox`，default `"  JPG"`→`0`（JPG）。
2. `Settings.cpp::init`：为 `picformat` 填充下拉项 `["JPG","PNG"]`（`setData("items", ...)`）。
3. `Settings.cpp::onValueChanged`：新增 `picformat` 分支，发出 `photoFormatChanged(QString)`（带越界保护，镜像 `vidformat`）。
4. `Settings.h`：声明 `photoFormatChanged(QString)` 信号。

`combobox` 为 DTK 内建类型，`DSettingsDialog` 自动渲染下拉框，无需自定义工厂；`formatLabel` 工厂注册保留（panel 模式 `vidformat` 仍用）。

## 改动安全评估

低风险。`onValueChanged` 仅通过 `connect(DSettings::valueChanged)` 接入，无直接调用者；本次为纯新增兄弟分支，不改签名、不触碰既有分支（含近期 shutter-audio 修复逻辑），无回归风险。

## 已知遗留（本次按批准范围仅修 Settings 侧）

`photoFormatChanged` 信号当前**无消费者**：照片保存路径仍硬编码 `.jpg`（`videowidget.cpp:771`）与 `img.save(...,"JPG")`（`majorimageprocessingthread.cpp:123/421/440`）。即用户选 PNG 时照片仍以 JPG 保存。完整端到端（PNG 实际保存）需追加 `videowidget.cpp` / `majorimageprocessingthread.cpp` / `mainwindow.cpp` 消费侧接线，超出本次批准文件范围，留待后续。

## Summary by Sourcery

Switch photo output format setting to a combobox and emit a dedicated change signal for it.

New Features:
- Add a configurable photo output format with JPG/PNG options exposed via a combobox in the settings UI.

Enhancements:
- Wire the photo output format setting into the settings change flow by emitting a photoFormatChanged signal when the value changes.