### PR TITLE
fix(ui): fix frozen separator lines in filter thumbnail column

### DIFF
--- a/src/src/filterpreviewbutton.cpp
+++ b/src/src/filterpreviewbutton.cpp
@@ -49,6 +49,11 @@ filterPreviewButton::filterPreviewButton(QWidget *parent, efilterType filter/* =
     m_disableSelect = false;
 
     setWindowOpacity(0.1);
+    // 按钮只画中央 40x40 图像与描边，5px 边距不绘制。未设透明时 Qt 把按钮当
+    // 不透明处理，边距区不会与下层视频混合，残留首帧像素形成冻结边带。设为
+    // 透明后边距透出视频，与 2px 间隙行为一致。
+    setAttribute(Qt::WA_TranslucentBackground, true);
+    setAutoFillBackground(false);
     resize(BUTTON_SIZE, BUTTON_SIZE);
 
     qDebug() << "Function completed: filterPreviewButton constructor";

--- a/src/src/takephotosettingareawidget.cpp
+++ b/src/src/takephotosettingareawidget.cpp
@@ -151,6 +151,15 @@ void takePhotoSettingAreaWidget::initButtons()
     m_filtersUnfoldBtn->setFocusPolicy(Qt::NoFocus);
 
     //滤镜滚动条窗口
+    // 滤镜缩略图按设计无面板背景，直接浮在视频画面之上（paintEvent 中滤镜组
+    // 分支不画底色）。要让按钮之间的 2px 间隙、以及按钮自身的 5px 边距真正透出
+    // 底层视频，整条链都必须是透明的：仅给 m_scrollAreaWidget 设透明无效，
+    // 因为它透出去看到的是 QScrollArea viewport 的不透明底色——表现为一条静止
+    // 的分割线。这里给 this、m_scrollArea、viewport 同时设 WA_TranslucentBackground
+    // 并关掉 viewport 自动填充，让透明一直贯通到视频所在层。
+    // 注：Wayland 下视频由 QGraphicsView 渲染、m_openglwidget 为 nullptr；
+    // X11 下才是 QOpenGLWidget。两条路径都依赖此透明链。
+    setAttribute(Qt::WA_TranslucentBackground, true);
     m_scrollAreaWidget = new QWidget(this);
     m_scrollAreaWidget->setAttribute(Qt::WA_TranslucentBackground, true);
     QVBoxLayout *scrollLayout = new QVBoxLayout(m_scrollAreaWidget);
@@ -159,7 +168,13 @@ void takePhotoSettingAreaWidget::initButtons()
     m_scrollAreaWidget->setLayout(scrollLayout);
     m_scrollArea = new QScrollArea(this);
     m_scrollArea->setFrameShape(QFrame::NoFrame);
+    m_scrollArea->setAttribute(Qt::WA_TranslucentBackground, true);
+    m_scrollArea->setAutoFillBackground(false);
     m_scrollArea->setWidget(m_scrollAreaWidget);
+    // viewport 默认 autoFillBackground 且用 palette Window 填充（不透明），
+    // 是分割线的直接来源；关掉它并设透明，链才算通。
+    m_scrollArea->viewport()->setAutoFillBackground(false);
+    m_scrollArea->viewport()->setAttribute(Qt::WA_TranslucentBackground, true);
     m_scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_scrollArea->setVisible(false);
 
@@ -1358,6 +1373,18 @@ void takePhotoSettingAreaWidget::onUpdateFilterImage(QImage *img)
     for (auto btn : m_filterPreviewBtnList) {
         QImage tmp = img->copy();
         btn->setImage(&tmp);
+    }
+
+    // 滤镜列透明悬浮在视频画面之上（Wayland 为 QGraphicsView，X11 为
+    // QOpenGLWidget，二者互为兄弟子树）。缩略图本身每帧由 setImage() 重绘，
+    // 但按钮之间的 2px 间隙、按钮 5px 边距属于本控件/按钮的透明区域，Qt 不会
+    // 因下层视频刷新而自动跨子树重新混合它们——只在 show/hide 时合成一次，
+    // 之后随视频帧“冻结在首帧”，表现为静止的分割线。这里随每帧主动 update()
+    // 一次，强制把透明层在最新一帧视频上重新合成，消除冻结的分割线，同时
+    // 保留透明背景（不引入底色）。透明链在 initButtons() 中已对 this、
+    // m_scrollArea、viewport、m_scrollAreaWidget 一并设好，此处才能生效。
+    if (m_scrollArea && m_scrollArea->isVisible()) {
+        m_scrollAreaWidget->update();
     }
     qDebug() << "Exiting onUpdateFilterImage";
 }


### PR DESCRIPTION
1. Set WA_TranslucentBackground on filterPreviewButton and disable autoFillBackground so the 5px margin blends with the video layer
2. Propagate transparency through this, m_scrollArea, viewport and m_scrollAreaWidget in initButtons to reach the video render layer
3. Call m_scrollAreaWidget->update() per frame in onUpdateFilterImage to re-composite the transparent layer over the latest video frame

Log: Fix frozen separator lines/bands between filter thumbnails by completing the transparency chain to the video layer and re-compositing per frame Influence: Eliminates frozen separator lines without adding background

fix(ui): 修复滤镜缩略图列冻结分割线/边带

1. 滤镜按钮设 WA_TranslucentBackground 并关闭 autoFillBackground， 使 5px 边距透出视频
2. initButtons 中沿 this、m_scrollArea、viewport、m_scrollAreaWidget 整链设透明并关自动填充，贯通到视频渲染层
3. onUpdateFilterImage 每帧主动 update m_scrollAreaWidget，在最新 视频帧上重新合成透明层，消除冻结分割线

Log: 贯通透明链到视频层并每帧重合成，修复滤镜缩略图间冻结分割线
PMS: [BUG-169219](https://pms.uniontech.com/bug-view-169219.html)
Influence: 消除冻结分割线且不引入底色

## Summary by Sourcery

Resolve visual freezing of separator lines between filter thumbnails by making the thumbnail column truly transparent over the video and re-compositing it every frame.

Bug Fixes:
- Eliminate frozen separator lines/bands between filter thumbnails in the take photo settings UI.

Enhancements:
- Ensure the filter thumbnail scroll area and its children use a fully transparent background chain down to the video render layer.
- Make filter preview buttons treat their margin area as transparent so underlying video shows through consistently.