### PR TITLE
fix: sync resolution config after prepare_new_resolution (#372317)

### DIFF
--- a/src/src/LPF_V4L2.c
+++ b/src/src/LPF_V4L2.c
@@ -220,6 +220,8 @@ int camInit(const char *devicename)
                 my_config->height = get_my_height();
             } else {
                 v4l2core_prepare_new_resolution(my_vd, my_config->width, my_config->height);
+                my_config->width  = get_my_width();
+                my_config->height = get_my_height();
             }
             ret = v4l2core_update_old_format(my_vd, my_config->width, my_config->height, v4l2core_get_requested_frame_format(my_vd));
         } else {


### PR DESCRIPTION
Sync my_config width/height with actual values after v4l2core_prepare_new_resolution to avoid config mismatch.

在 v4l2core_prepare_new_resolution 调用后同步 my_config 的 宽高配置，避免配置值与实际分辨率不一致。

Log: 同步分辨率配置
PMS: BUG-372317
Influence: 修复相机分辨率配置与实际设置不同步的问题，确保配置文件记录的分辨率与实际使用的分辨率一致。

## Summary by Sourcery

Bug Fixes:
- Synchronize the stored camera width and height with the actual resolution after preparing a new resolution, preventing configuration mismatches.