### PR TITLE
fix(ui): enable QPainter antialiasing for Qt6 build

### DIFF
--- a/src/src/switchcamerabtn.cpp
+++ b/src/src/switchcamerabtn.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,6 +27,7 @@ void SwitchCameraBtn::paintEvent(QPaintEvent *event)
     // qDebug() << "Function started: SwitchCameraBtn::paintEvent";
     Q_UNUSED(event);
     QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
 #if QT_VERSION_MAJOR <= 5
     painter.setRenderHint(QPainter::HighQualityAntialiasing, true);
 #endif

--- a/src/src/takephotosettingareawidget.cpp
+++ b/src/src/takephotosettingareawidget.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1223,6 +1223,7 @@ void takePhotoSettingAreaWidget::paintEvent(QPaintEvent *event)
 {
     // qDebug() << "Entering paintEvent";
     QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
 #if QT_VERSION_MAJOR <= 5
     painter.setRenderHint(QPainter::HighQualityAntialiasing, true);
 #endif


### PR DESCRIPTION
Add QPainter::Antialiasing render hint for switchcamerabtn and takephotosettingareawidget, which were missing it under Qt6.

Qt6下switchcamerabtn和takephotosettingareawidget的paintEvent 未设置抗锯齿，导致圆形边框绘制出现锯齿。

Log: Qt6下开启抗锯齿修复边框锯齿
Influence: 修复Qt6下切换摄像头按钮和拍照设置区域边框锯齿问题，提升显示效果。

## Summary by Sourcery

Enable antialiasing for the affected widgets to improve border rendering in Qt6 builds.

Bug Fixes:
- Fix jagged circular borders in the camera-switch button and photo-settings area when built with Qt6 by enabling painter antialiasing.

Chores:
- Update copyright year ranges in the affected source files.