### PR TITLE
fix: update Arabic (ar) translations

### DIFF
--- a/src/translations/deepin-camera_ar.ts
+++ b/src/translations/deepin-camera_ar.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Open folder</source>
-        <translation type="vanished">فتح مجلد</translation>
+        <translation>فتح مجلد</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -74,7 +74,7 @@
     </message>
     <message>
         <source>Invalid folder</source>
-        <translation type="vanished">مجلد غير صالح</translation>
+        <translation>مجلد غير صالح</translation>
     </message>
     <message>
         <source>Open folder</source>
@@ -138,7 +138,7 @@
     </message>
     <message>
         <source>Save to:</source>
-        <translation type="vanished">حفظ إلى:</translation>
+        <translation>حفظ إلى:</translation>
     </message>
     <message>
         <source>Photo:</source>
@@ -154,7 +154,7 @@
     </message>
     <message>
         <source>Resolution:</source>
-        <translation type="vanished">الدِّقَّة:</translation>
+        <translation>الدِّقَّة:</translation>
     </message>
     <message>
         <source>Photos:</source>
@@ -244,15 +244,15 @@
     <name>ThumbnailsBar</name>
     <message>
         <source>Take photo</source>
-        <translation type="vanished">التقاط صورة</translation>
+        <translation>التقاط صورة</translation>
     </message>
     <message>
         <source>Record video</source>
-        <translation type="vanished">تسجيل فيديو</translation>
+        <translation>تسجيل فيديو</translation>
     </message>
     <message>
         <source>Stop taking photos</source>
-        <translation type="vanished">إيقاف التقاط الصور</translation>
+        <translation>إيقاف التقاط الصور</translation>
     </message>
 </context>
 <context>
@@ -348,7 +348,7 @@
     </message>
     <message>
         <source>Stop recording</source>
-        <translation type="vanished">إيقاف التسجيل</translation>
+        <translation>إيقاف التسجيل</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Update Arabic (ar) translation files to complete all unfinished entries.

## Summary by Sourcery

Bug Fixes:
- Activate previously marked-as-vanished Arabic translations for camera actions, folder handling, photo settings, and recording controls.