### PR TITLE
chore: update version to 6.5.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-camera (6.5.48) unstable; urgency=medium
+
+  * fix(a11y): add AT-SPI names for exposure slider and image menu
+  * fix: update Arabic (ar) translations
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Mon, 07 Sep 2026 13:27:52 +0800
+
 deepin-camera (6.5.47) unstable; urgency=medium
 
   * fix(ui): enable QPainter antialiasing for Qt6 build

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.camera
   name: "deepin-camera"
-  version: 6.5.47.1
+  version: 6.5.48.1
   kind: app
   description: |
     camera for deepin os.


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Bump the deepin-camera package to version 6.5.48.1 and record the release in the changelog.

Chores:
- Update the Debian changelog for the new release.
- Bump the application package version from 6.5.47.1 to 6.5.48.1.